### PR TITLE
Configuration for hal+json

### DIFF
--- a/Annotation/Content.php
+++ b/Annotation/Content.php
@@ -9,8 +9,6 @@ namespace FSC\HateoasBundle\Annotation;
 final class Content
 {
     /**
-     * @Required
-     *
      * @var array<string>
      */
     public $provider;
@@ -34,4 +32,9 @@ final class Content
      * @var boolean
      */
     public $serializerXmlElementNameRootMetadata;
+
+    /**
+     * @var string
+     */
+    public $property;
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,6 +28,13 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
             ->booleanNode('form_handler')->defaultValue(false)->end()
+            ->arrayNode('json')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('links')->defaultValue('links')->end()
+                    ->scalarNode('relations')->defaultValue('relations')->end()
+                ->end()
+            ->end()
         ;
 
         $this->addMetadataSection($root);

--- a/DependencyInjection/FSCHateoasExtension.php
+++ b/DependencyInjection/FSCHateoasExtension.php
@@ -30,6 +30,21 @@ class FSCHateoasExtension extends ConfigurableExtension
             ;
         }
 
+        $container
+            ->getDefinition('fsc_hateoas.serializer.event_subscriber.link')
+            ->replaceArgument(2, $config['json'])
+        ;
+
+        $container
+            ->getDefinition('fsc_hateoas.serializer.event_subscriber.embedder')
+            ->replaceArgument(4, null)
+        ;
+
+        $container
+            ->getDefinition('fsc_hateoas.serializer.event_subscriber.embedder')
+            ->replaceArgument(5, $config['json'])
+        ;
+
         $this->configureMetadata($config, $container);
     }
 

--- a/Factory/PropertyFactory.php
+++ b/Factory/PropertyFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace FSC\HateoasBundle\Factory;
+
+class PropertyFactory
+{
+	/**
+	 * Returns the property
+	 * @param  mixed $property
+	 * @return mixed
+	 */
+	public function retrieveProperty($property)
+	{
+		return $property;
+	}
+}

--- a/Factory/PropertyFactory.php
+++ b/Factory/PropertyFactory.php
@@ -4,13 +4,13 @@ namespace FSC\HateoasBundle\Factory;
 
 class PropertyFactory
 {
-	/**
-	 * Returns the property
-	 * @param  mixed $property
-	 * @return mixed
-	 */
-	public function retrieveProperty($property)
-	{
-		return $property;
-	}
+    /**
+     * Returns the property
+     * @param  mixed $property
+     * @return mixed
+     */
+    public function retrieveProperty($property)
+    {
+        return $property;
+    }
 }

--- a/Metadata/Builder/RelationsMetadataBuilder.php
+++ b/Metadata/Builder/RelationsMetadataBuilder.php
@@ -30,14 +30,30 @@ class RelationsMetadataBuilder implements RelationsMetadataBuilderInterface
         }
 
         if (null !== $embed) {
-            if (!isset($embed['provider']) || 2 !== count($embed['provider'])) {
+            if (!empty($embed['provider']) && !empty($embed['property'])) {
+                throw new \RuntimeException("content configuration can only have either a provider or a property.");
+            } elseif (empty($embed['provider']) && empty($embed['property'])) {
+                throw new \RuntimeException("The content configuration needs either a provider or a property.");
+            } elseif (isset($embed['provider']) && 2 !== count($embed['provider'])) {
                 throw new \RuntimeException('content "provider" is required, and should be an array of 2 values. [service, method]');
             }
 
-            $contentMetadata = new RelationContentMetadata($embed['provider'][0], $embed['provider'][1]);
+            if (!empty($embed['provider'])) {
+                $providerId     = $embed['provider'][0];
+                $providerMethod = $embed['provider'][1];
+            } else {
+                $providerId     = "fsc_hateoas.factory.property";
+                $providerMethod = "retrieveProperty";
+            }
+
+            $contentMetadata = new RelationContentMetadata($providerId, $providerMethod);
 
             if (isset($embed['providerArguments'])) {
                 $contentMetadata->setProviderArguments($embed['providerArguments']);
+            }
+
+            if (isset($embed['property'])) {
+                $contentMetadata->setProviderArguments(array($embed['property']));
             }
 
             if (isset($embed['serializerType'])) {

--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -60,7 +60,7 @@ class AnnotationDriver implements DriverInterface
                     } else {
                         $relationContentMetadata = new RelationContentMetadata("fsc_hateoas.factory.property", "retrieveProperty");
                         $relationMetadata->setContent($relationContentMetadata);
-                        $relationContentMetadata->setProviderArguments(array('property' => $annotation->embed->property));
+                        $relationContentMetadata->setProviderArguments(array($annotation->embed->property));
                     }
 
                     $relationContentMetadata->setSerializerType($annotation->embed->serializerType);

--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -41,14 +41,28 @@ class AnnotationDriver implements DriverInterface
                 }
 
                 if (null !== $annotation->embed && $annotation->embed instanceof Annotation\Content) {
-                    if (2 !== count($annotation->embed->provider)) {
-                        throw new \RuntimeException('The @Content provider paremeters should be an array of 2 values, a service id and a method.');
+                    if (empty($annotation->embed->provider) && empty($annotation->embed->property)) {
+                        throw new \RuntimeException("The @Content annotation needs either a provider or a property.");
                     }
 
-                    $relationContentMetadata = new RelationContentMetadata($annotation->embed->provider[0], $annotation->embed->provider[1]);
-                    $relationMetadata->setContent($relationContentMetadata);
+                    if (!empty($annotation->embed->provider) && !empty($annotation->embed->property)) {
+                        throw new \RuntimeException("The @Content annotation can only have either a provider or a property.");
+                    }
 
-                    $relationContentMetadata->setProviderArguments($annotation->embed->providerArguments ?: array());
+                    if (!empty($annotation->embed->provider)) {
+                        if (2 !== count($annotation->embed->provider)) {
+                            throw new \RuntimeException('The @Content provider parameters should be an array of 2 values, a service id and a method.');
+                        }
+
+                        $relationContentMetadata = new RelationContentMetadata($annotation->embed->provider[0], $annotation->embed->provider[1]);
+                        $relationMetadata->setContent($relationContentMetadata);
+                        $relationContentMetadata->setProviderArguments($annotation->embed->providerArguments ?: array());
+                    } else {
+                        $relationContentMetadata = new RelationContentMetadata("fsc_hateoas.factory.property", "retrieveProperty");
+                        $relationMetadata->setContent($relationContentMetadata);
+                        $relationContentMetadata->setProviderArguments(array('property' => $annotation->embed->property));
+                    }
+
                     $relationContentMetadata->setSerializerType($annotation->embed->serializerType);
                     $relationContentMetadata->setSerializerXmlElementName($annotation->embed->serializerXmlElementName);
                     $relationContentMetadata->setSerializerXmlElementRootName($annotation->embed->serializerXmlElementNameRootMetadata);

--- a/Metadata/Driver/YamlDriver.php
+++ b/Metadata/Driver/YamlDriver.php
@@ -43,11 +43,30 @@ class YamlDriver extends AbstractFileDriver
 
                 if (!empty($relation['content'])) {
                     $relationContent = $relation['content'];
-                    $relationContentMetadata = new RelationContentMetadata($relationContent['provider_id'], $relationContent['provider_method']);
+
+                    if (!empty($relationContent['provider_id']) && !empty($relationContent['property'])) {
+                        throw new \RuntimeException("The content configuration can only have either a provider or a property.");
+                    }
+
+                    if (!empty($relationContent['provider_id']) && !empty($relationContent['provider_method'])) {
+                        $providerId     = $relationContent['provider_id'];
+                        $providerMethod = $relationContent['provider_method'];
+                    } elseif (!empty($relationContent['property'])) {
+                        $providerId     = "fsc_hateoas.factory.property";
+                        $providerMethod = "retrieveProperty";
+                    } else {
+                        throw new \RuntimeException("The content configuration needs either a provider or a property.");
+                    }
+
+                    $relationContentMetadata = new RelationContentMetadata($providerId, $providerMethod);
                     $relationMetadata->setContent($relationContentMetadata);
 
                     if (isset($relationContent['provider_arguments'])) {
                         $relationContentMetadata->setProviderArguments($relationContent['provider_arguments']);
+                    }
+
+                    if (isset($relationContent['property'])) {
+                        $relationContentMetadata->setProviderArguments(array($relationContent['property']));
                     }
 
                     if (isset($relationContent['serializer_type'])) {

--- a/README.md
+++ b/README.md
@@ -97,6 +97,22 @@ or
 }
 ```
 
+## Json Format
+
+The bundle supports customizing the keys of links and embedded relations when serializing to Json. They are
+controlled by the following configuration:
+
+```yml
+# app/config/config.yml
+
+fsc_hateoas:
+    json:
+        links: _links         # default: links
+        relations: _embedded  # default: relations
+```
+
+The above configuration will result in serialization to valid [hal+json](http://stateless.co/hal_specification.html).
+
 ## Pagerfanta Handler
 
 Default configuration:
@@ -214,7 +230,7 @@ public function getListAction(Request $request, $page = 1, $limit = 10)
 
 Sometimes, your representations have embedded relations that require a service to be fetched, or need to be paginated.
 To embed a relation using this bundle, you create a simple Relation metadata (with an annotation for example),
-and add extra "content" parameters.
+and add extra "content" parameter.
 
 Example:
 
@@ -256,7 +272,7 @@ class Controller extends Controller
 
 ### Model and serializer/hateoas metadata
 
-*Note that you can also configure serializer/hateoas metadatas using yaml to keep serialisation out of your model*
+*Note that you can also configure serializer/hateoas metadata using yaml to keep serialisation out of your model*
 
 ```php
 <?php
@@ -366,3 +382,42 @@ and `GET /api/users/42/friends` would result in
   </user>
 </users>
 ```
+
+### Embedding relations from properties
+
+Instead of defining a service to embed resources you can also embed resources, that are properties of your main
+resource.
+
+```php
+<?php
+
+// src/Acme/FooBundle/Entity/User.php
+
+use JMS\SerializerBundle\Annotation as Serializer;
+use FSC\HateoasBundle\Annotation as Rest;
+
+/**
+ * @Rest\Relation("self", href = @Rest\Route("api_user_get", parameters = { "id" = ".id" }))
+ * @Rest\Relation("friends",
+ *     href =  @Rest\Route("api_user_friends_list", parameters = { "id" = ".id" }),
+ *     embed = @Rest\Content(
+ *         property = ".friends"
+ *     )
+ * )
+ *
+ * @Serializer\XmlRoot("user")
+ */
+class User
+{
+    ...
+
+    /**
+     * @var array<User>
+     */
+    private $friends;
+}
+```
+
+This will serialize the `friends` property and embed it as a relation.
+
+

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -12,6 +12,9 @@ parameters:
     fsc_hateoas.serializer.handler.links_aware_wrapper.class: FSC\HateoasBundle\Serializer\Handler\LinksAwareWrapperHandler
     fsc_hateoas.serializer.handler.form_view.class: FSC\HateoasBundle\Serializer\Handler\FormViewHandler
     fsc_hateoas.serializer.handler.form.class: FSC\HateoasBundle\Serializer\Handler\FormHandler
+    fsc_hateoas.json_options: ~
+    fsc_hateoas.factory.property.class: FSC\HateoasBundle\Factory\PropertyFactory
+    fsc_hateoas.event_subscriber.typeparser: ~
 
 services:
     fsc_hateoas.serializer.link_serialization_helper:
@@ -59,6 +62,7 @@ services:
         arguments:
             - @fsc_hateoas.factory.link
             - @fsc_hateoas.serializer.link_serialization_helper
+            - %fsc_hateoas.json_options%
         tags:
             - { name: jms_serializer.event_subscriber }
 
@@ -69,6 +73,8 @@ services:
             - @jms_serializer.metadata_factory
             - @fsc_hateoas.factory.links_aware_wrapper
             - @fsc_hateoas.factory.parameters
+            - %fsc_hateoas.event_subscriber.typeparser%
+            - %fsc_hateoas.json_options%
         tags:
             - { name: jms_serializer.event_subscriber }
 
@@ -99,3 +105,6 @@ services:
         tags:
             # Added by DI extension
             #- { name: jms_serializer.subscribing_handler }
+
+    fsc_hateoas.factory.property:
+        class: %fsc_hateoas.factory.property.class%

--- a/Serializer/EventSubscriber/EmbedderEventSubscriber.php
+++ b/Serializer/EventSubscriber/EmbedderEventSubscriber.php
@@ -8,8 +8,6 @@ use JMS\SerializerBundle\Serializer\XmlSerializationVisitor;
 use JMS\SerializerBundle\Serializer\EventDispatcher\Events;
 use JMS\SerializerBundle\Serializer\EventDispatcher\Event;
 use Metadata\MetadataFactoryInterface;
-use Symfony\Component\Form\Util\PropertyPath;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 use FSC\HateoasBundle\Factory\ContentFactoryInterface;
 use FSC\HateoasBundle\Factory\LinksAwareWrapperFactoryInterface;
@@ -116,7 +114,7 @@ class EmbedderEventSubscriber implements EventSubscriberInterface
 
         if (null !== $relationMetadata->getContent()->getSerializerXmlElementName()) {
             $elementName = $relationMetadata->getContent()->getSerializerXmlElementName();
-        } else if (null !== $relationMetadata->getContent()->getSerializerXmlElementRootName()) {
+        } elseif (null !== $relationMetadata->getContent()->getSerializerXmlElementRootName()) {
             $classMetadata = $this->serializerMetadataFactory->getMetadataForClass(get_class($content));
             $elementName = $classMetadata->xmlRootName ?: $elementName;
         }

--- a/Serializer/EventSubscriber/EmbedderEventSubscriber.php
+++ b/Serializer/EventSubscriber/EmbedderEventSubscriber.php
@@ -41,15 +41,22 @@ class EmbedderEventSubscriber implements EventSubscriberInterface
     protected $linksAwareWrapperFactory;
     protected $parametersFactory;
     protected $typeParser;
+    protected $embeddedCollectionName;
 
-    public function __construct(ContentFactoryInterface $contentFactory, MetadataFactoryInterface $serializerMetadataFactory,
-        LinksAwareWrapperFactoryInterface $linksAwareWrapperFactory, ParametersFactoryInterface $parametersFactory, TypeParser $typeParser = null)
-    {
+    public function __construct(
+        ContentFactoryInterface $contentFactory,
+        MetadataFactoryInterface $serializerMetadataFactory,
+        LinksAwareWrapperFactoryInterface $linksAwareWrapperFactory,
+        ParametersFactoryInterface $parametersFactory,
+        TypeParser $typeParser = null,
+        array $jsonOptions
+    ) {
         $this->contentFactory = $contentFactory;
         $this->serializerMetadataFactory = $serializerMetadataFactory;
         $this->linksAwareWrapperFactory = $linksAwareWrapperFactory;
         $this->parametersFactory = $parametersFactory;
         $this->typeParser = $typeParser ?: new TypeParser();
+        $this->embeddedCollectionName = $jsonOptions['relations'];
     }
 
     public function onPostSerializeXML(Event $event)
@@ -100,7 +107,7 @@ class EmbedderEventSubscriber implements EventSubscriberInterface
             );
         }
 
-        $event->getVisitor()->addData('relations', $relationsData);
+        $event->getVisitor()->addData($this->embeddedCollectionName, $relationsData);
     }
 
     protected function getRelationXmlElementName(RelationMetadataInterface $relationMetadata, $content)

--- a/Serializer/EventSubscriber/LinkEventSubscriber.php
+++ b/Serializer/EventSubscriber/LinkEventSubscriber.php
@@ -5,7 +5,6 @@ namespace FSC\HateoasBundle\Serializer\EventSubscriber;
 use JMS\SerializerBundle\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\SerializerBundle\Serializer\EventDispatcher\Events;
 use JMS\SerializerBundle\Serializer\EventDispatcher\Event;
-use JMS\SerializerBundle\Serializer\TypeParser;
 
 use FSC\HateoasBundle\Factory\LinkFactoryInterface;
 use FSC\HateoasBundle\Serializer\LinkSerializationHelper;

--- a/Serializer/EventSubscriber/LinkEventSubscriber.php
+++ b/Serializer/EventSubscriber/LinkEventSubscriber.php
@@ -34,11 +34,14 @@ class LinkEventSubscriber implements EventSubscriberInterface
 
     protected $linkFactory;
     protected $linkSerializationHelper;
+    protected $linksCollectionName;
 
-    public function __construct(LinkFactoryInterface $linkFactory, LinkSerializationHelper $linkSerializationHelper)
+    public function __construct(LinkFactoryInterface $linkFactory, LinkSerializationHelper $linkSerializationHelper, array $jsonOptions)
     {
         $this->linkFactory = $linkFactory;
         $this->linkSerializationHelper = $linkSerializationHelper;
+        $this->jsonOptions = $jsonOptions;
+        $this->linksCollectionName = $jsonOptions['links'];
     }
 
     public function onPostSerializeXML(Event $event)
@@ -57,6 +60,6 @@ class LinkEventSubscriber implements EventSubscriberInterface
         }
 
         $visitor = $event->getVisitor();
-        $visitor->addData('links', $this->linkSerializationHelper->createGenericLinksData($links, $visitor));
+        $visitor->addData($this->linksCollectionName, $this->linkSerializationHelper->createGenericLinksData($links, $visitor));
     }
 }

--- a/Tests/Fixtures/User.php
+++ b/Tests/Fixtures/User.php
@@ -22,11 +22,16 @@ use FSC\HateoasBundle\Annotation as Rest;
  *          serializerXmlElementName = "favorites"
  *     )
  * )
+ * @Rest\Relation("disclosure",
+ *     href = @Rest\Route("homepage"),
+ *     embed = @Rest\Content(property = ".property")
+ * )
  */
 class User
 {
     private $id;
     private $username;
+    private $property;
 
     public function setId($id)
     {

--- a/Tests/Metadata/Builder/RelationsMetadataBuilderTest.php
+++ b/Tests/Metadata/Builder/RelationsMetadataBuilderTest.php
@@ -90,4 +90,30 @@ class RelationMetadatasBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($xmlName, $relationsMetadata[0]->getContent()->getSerializerXmlElementName());
         $this->assertEquals($xmlRootMetadata, $relationsMetadata[0]->getContent()->getSerializerXmlElementRootName());
     }
+
+    public function testAddEmbeddedRelationProperty()
+    {
+        $RelationsMetadataBuilder = new RelationsMetadataBuilder();
+
+        $RelationsMetadataBuilder->add('self',
+            array(
+                'route' => '_some_route',
+            ), array(
+                'property' => '.someProperty',
+                'serializerType' => 'array<Foo>',
+                'serializerXmlElementName' => $xmlName = 'users',
+                'serializerXmlElementRootMetadata' => $xmlRootMetadata = true,
+            )
+        );
+
+        $relationsMetadata = $RelationsMetadataBuilder->build();
+        $this->assertInternalType('array', $relationsMetadata);
+
+        $this->assertInstanceOf('FSC\HateoasBundle\Metadata\RelationContentMetadataInterface', $relationsMetadata[0]->getContent());
+        $this->assertEquals('fsc_hateoas.factory.property', $relationsMetadata[0]->getContent()->getProviderId());
+        $this->assertEquals('retrieveProperty', $relationsMetadata[0]->getContent()->getProviderMethod());
+        $this->assertEquals(array('.someProperty'), $relationsMetadata[0]->getContent()->getProviderArguments());
+        $this->assertEquals($xmlName, $relationsMetadata[0]->getContent()->getSerializerXmlElementName());
+        $this->assertEquals($xmlRootMetadata, $relationsMetadata[0]->getContent()->getSerializerXmlElementRootName());
+    }
 }

--- a/Tests/Metadata/Driver/CommonDriverTest.php
+++ b/Tests/Metadata/Driver/CommonDriverTest.php
@@ -114,6 +114,17 @@ class CommonDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Pagerfanta<custom>', $relationMetadata->getContent()->getSerializerType());
         $this->assertEquals('favorites', $relationMetadata->getContent()->getSerializerXmlElementName());
         $this->assertFalse($relationMetadata->getContent()->getSerializerXmlElementRootName());
+
+        $n++;
+
+        $relationMetadata = $relationsMetadata[$n];
+        $this->assertEquals('disclosure', $relationMetadata->getRel());
+        $this->assertEquals('homepage', $relationMetadata->getRoute());
+        $this->assertInstanceOf('FSC\HateoasBundle\Metadata\RelationContentMetadataInterface', $relationMetadata->getContent());
+        $this->assertEquals('fsc_hateoas.factory.property', $relationMetadata->getContent()->getProviderId());
+        $this->assertEquals('retrieveProperty', $relationMetadata->getContent()->getProviderMethod());
+        $this->assertEquals(array('.property'), $relationMetadata->getContent()->getProviderArguments());
+
 return;
     }
 }

--- a/Tests/Metadata/Driver/yml/User.yml
+++ b/Tests/Metadata/Driver/yml/User.yml
@@ -29,3 +29,8 @@ FSC\HateoasBundle\Tests\Fixtures\User:
               provider_arguments: [ id, =3 ]
               serializer_type: Pagerfanta<custom>
               serializer_xml_element_name: favorites
+        - rel: disclosure
+          href:
+            route: homepage
+          content:
+            property: .property


### PR DESCRIPTION
## Configuration required to serialize to hal+ json

Added the ability to specify what the keys in the json serialization is for links and relations. That way, proper hal+json serialization is possible. 
## Property based relation embedding

Added a property factory that allows to make properties embedded relations. This avoids having to create services.

Please let me know if you want me to add anything. Thanks.
