### PR TITLE
Configuration for hal+json

### DIFF
--- a/Annotation/Content.php
+++ b/Annotation/Content.php
@@ -9,8 +9,6 @@ namespace FSC\HateoasBundle\Annotation;
 final class Content
 {
     /**
-     * @Required
-     *
      * @var array<string>
      */
     public $provider;
@@ -34,4 +32,9 @@ final class Content
      * @var boolean
      */
     public $serializerXmlElementNameRootMetadata;
+
+    /**
+     * @var string
+     */
+    public $property;
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,6 +28,13 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
             ->booleanNode('form_handler')->defaultValue(false)->end()
+            ->arrayNode('json')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->scalarNode('links')->defaultValue('links')->end()
+                    ->scalarNode('relations')->defaultValue('relations')->end()
+                ->end()
+            ->end()
         ;
 
         $this->addMetadataSection($root);

--- a/DependencyInjection/FSCHateoasExtension.php
+++ b/DependencyInjection/FSCHateoasExtension.php
@@ -30,20 +30,7 @@ class FSCHateoasExtension extends ConfigurableExtension
             ;
         }
 
-        $container
-            ->getDefinition('fsc_hateoas.serializer.event_subscriber.link')
-            ->replaceArgument(2, $config['json'])
-        ;
-
-        $container
-            ->getDefinition('fsc_hateoas.serializer.event_subscriber.embedder')
-            ->replaceArgument(4, null)
-        ;
-
-        $container
-            ->getDefinition('fsc_hateoas.serializer.event_subscriber.embedder')
-            ->replaceArgument(5, $config['json'])
-        ;
+        $container->setParameter('fsc_hateoas.json_options', $config['json']);
 
         $this->configureMetadata($config, $container);
     }

--- a/DependencyInjection/FSCHateoasExtension.php
+++ b/DependencyInjection/FSCHateoasExtension.php
@@ -30,6 +30,21 @@ class FSCHateoasExtension extends ConfigurableExtension
             ;
         }
 
+        $container
+            ->getDefinition('fsc_hateoas.serializer.event_subscriber.link')
+            ->replaceArgument(2, $config['json'])
+        ;
+
+        $container
+            ->getDefinition('fsc_hateoas.serializer.event_subscriber.embedder')
+            ->replaceArgument(4, null)
+        ;
+
+        $container
+            ->getDefinition('fsc_hateoas.serializer.event_subscriber.embedder')
+            ->replaceArgument(5, $config['json'])
+        ;
+
         $this->configureMetadata($config, $container);
     }
 

--- a/Factory/IdentityFactory.php
+++ b/Factory/IdentityFactory.php
@@ -2,14 +2,14 @@
 
 namespace FSC\HateoasBundle\Factory;
 
-class PropertyFactory
+class IdentityFactory
 {
     /**
      * Returns the property
      * @param  mixed $property
      * @return mixed
      */
-    public function retrieveProperty($property)
+    public function get($property)
     {
         return $property;
     }

--- a/Factory/PropertyFactory.php
+++ b/Factory/PropertyFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace FSC\HateoasBundle\Factory;
+
+class PropertyFactory
+{
+	/**
+	 * Returns the property
+	 * @param  mixed $property
+	 * @return mixed
+	 */
+	public function retrieveProperty($property)
+	{
+		return $property;
+	}
+}

--- a/Factory/PropertyFactory.php
+++ b/Factory/PropertyFactory.php
@@ -4,13 +4,13 @@ namespace FSC\HateoasBundle\Factory;
 
 class PropertyFactory
 {
-	/**
-	 * Returns the property
-	 * @param  mixed $property
-	 * @return mixed
-	 */
-	public function retrieveProperty($property)
-	{
-		return $property;
-	}
+    /**
+     * Returns the property
+     * @param  mixed $property
+     * @return mixed
+     */
+    public function retrieveProperty($property)
+    {
+        return $property;
+    }
 }

--- a/Metadata/Builder/RelationsBuilder.php
+++ b/Metadata/Builder/RelationsBuilder.php
@@ -32,9 +32,11 @@ class RelationsBuilder implements RelationsBuilderInterface
         if (null !== $embed) {
             if (!empty($embed['provider']) && !empty($embed['property'])) {
                 throw new \RuntimeException("content configuration can only have either a provider or a property.");
-            } elseif (empty($embed['provider']) && empty($embed['property'])) {
+            } 
+            if (empty($embed['provider']) && empty($embed['property'])) {
                 throw new \RuntimeException("The content configuration needs either a provider or a property.");
-            } elseif (isset($embed['provider']) && 2 !== count($embed['provider'])) {
+            }
+            if (isset($embed['provider']) && 2 !== count($embed['provider'])) {
                 throw new \RuntimeException('content "provider" is required, and should be an array of 2 values. [service, method]');
             }
 

--- a/Metadata/Builder/RelationsBuilder.php
+++ b/Metadata/Builder/RelationsBuilder.php
@@ -30,14 +30,30 @@ class RelationsBuilder implements RelationsBuilderInterface
         }
 
         if (null !== $embed) {
-            if (!isset($embed['provider']) || 2 !== count($embed['provider'])) {
+            if (!empty($embed['provider']) && !empty($embed['property'])) {
+                throw new \RuntimeException("content configuration can only have either a provider or a property.");
+            } elseif (empty($embed['provider']) && empty($embed['property'])) {
+                throw new \RuntimeException("The content configuration needs either a provider or a property.");
+            } elseif (isset($embed['provider']) && 2 !== count($embed['provider'])) {
                 throw new \RuntimeException('content "provider" is required, and should be an array of 2 values. [service, method]');
             }
 
-            $contentMetadata = new RelationContentMetadata($embed['provider'][0], $embed['provider'][1]);
+            if (!empty($embed['provider'])) {
+                $providerId     = $embed['provider'][0];
+                $providerMethod = $embed['provider'][1];
+            } else {
+                $providerId     = "fsc_hateoas.factory.property";
+                $providerMethod = "retrieveProperty";
+            }
+
+            $contentMetadata = new RelationContentMetadata($providerId, $providerMethod);
 
             if (isset($embed['providerArguments'])) {
                 $contentMetadata->setProviderArguments($embed['providerArguments']);
+            }
+
+            if (isset($embed['property'])) {
+                $contentMetadata->setProviderArguments(array($embed['property']));
             }
 
             if (isset($embed['serializerType'])) {

--- a/Metadata/Builder/RelationsBuilder.php
+++ b/Metadata/Builder/RelationsBuilder.php
@@ -42,8 +42,8 @@ class RelationsBuilder implements RelationsBuilderInterface
                 $providerId     = $embed['provider'][0];
                 $providerMethod = $embed['provider'][1];
             } else {
-                $providerId     = "fsc_hateoas.factory.property";
-                $providerMethod = "retrieveProperty";
+                $providerId     = 'fsc_hateoas.factory.identity';
+                $providerMethod = 'get';
             }
 
             $contentMetadata = new RelationContentMetadata($providerId, $providerMethod);

--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -60,7 +60,7 @@ class AnnotationDriver implements DriverInterface
                     } else {
                         $relationContentMetadata = new RelationContentMetadata("fsc_hateoas.factory.property", "retrieveProperty");
                         $relationMetadata->setContent($relationContentMetadata);
-                        $relationContentMetadata->setProviderArguments(array('property' => $annotation->embed->property));
+                        $relationContentMetadata->setProviderArguments(array($annotation->embed->property));
                     }
 
                     $relationContentMetadata->setSerializerType($annotation->embed->serializerType);

--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -41,14 +41,28 @@ class AnnotationDriver implements DriverInterface
                 }
 
                 if (null !== $annotation->embed && $annotation->embed instanceof Annotation\Content) {
-                    if (2 !== count($annotation->embed->provider)) {
-                        throw new \RuntimeException('The @Content provider paremeters should be an array of 2 values, a service id and a method.');
+                    if (empty($annotation->embed->provider) && empty($annotation->embed->property)) {
+                        throw new \RuntimeException("The @Content annotation needs either a provider or a property.");
                     }
 
-                    $relationContentMetadata = new RelationContentMetadata($annotation->embed->provider[0], $annotation->embed->provider[1]);
-                    $relationMetadata->setContent($relationContentMetadata);
+                    if (!empty($annotation->embed->provider) && !empty($annotation->embed->property)) {
+                        throw new \RuntimeException("The @Content annotation can only have either a provider or a property.");
+                    }
 
-                    $relationContentMetadata->setProviderArguments($annotation->embed->providerArguments ?: array());
+                    if (!empty($annotation->embed->provider)) {
+                        if (2 !== count($annotation->embed->provider)) {
+                            throw new \RuntimeException('The @Content provider parameters should be an array of 2 values, a service id and a method.');
+                        }
+
+                        $relationContentMetadata = new RelationContentMetadata($annotation->embed->provider[0], $annotation->embed->provider[1]);
+                        $relationMetadata->setContent($relationContentMetadata);
+                        $relationContentMetadata->setProviderArguments($annotation->embed->providerArguments ?: array());
+                    } else {
+                        $relationContentMetadata = new RelationContentMetadata("fsc_hateoas.factory.property", "retrieveProperty");
+                        $relationMetadata->setContent($relationContentMetadata);
+                        $relationContentMetadata->setProviderArguments(array('property' => $annotation->embed->property));
+                    }
+
                     $relationContentMetadata->setSerializerType($annotation->embed->serializerType);
                     $relationContentMetadata->setSerializerXmlElementName($annotation->embed->serializerXmlElementName);
                     $relationContentMetadata->setSerializerXmlElementRootName($annotation->embed->serializerXmlElementNameRootMetadata);

--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -58,7 +58,7 @@ class AnnotationDriver implements DriverInterface
                         $relationMetadata->setContent($relationContentMetadata);
                         $relationContentMetadata->setProviderArguments($annotation->embed->providerArguments ?: array());
                     } else {
-                        $relationContentMetadata = new RelationContentMetadata("fsc_hateoas.factory.property", "retrieveProperty");
+                        $relationContentMetadata = new RelationContentMetadata('fsc_hateoas.factory.identity', 'get');
                         $relationMetadata->setContent($relationContentMetadata);
                         $relationContentMetadata->setProviderArguments(array($annotation->embed->property));
                     }

--- a/Metadata/Driver/YamlDriver.php
+++ b/Metadata/Driver/YamlDriver.php
@@ -43,11 +43,30 @@ class YamlDriver extends AbstractFileDriver
 
                 if (!empty($relation['content'])) {
                     $relationContent = $relation['content'];
-                    $relationContentMetadata = new RelationContentMetadata($relationContent['provider_id'], $relationContent['provider_method']);
+
+                    if (!empty($relationContent['provider_id']) && !empty($relationContent['property'])) {
+                        throw new \RuntimeException("The content configuration can only have either a provider or a property.");
+                    }
+
+                    if (!empty($relationContent['provider_id']) && !empty($relationContent['provider_method'])) {
+                        $providerId     = $relationContent['provider_id'];
+                        $providerMethod = $relationContent['provider_method'];
+                    } elseif (!empty($relationContent['property'])) {
+                        $providerId     = "fsc_hateoas.factory.property";
+                        $providerMethod = "retrieveProperty";
+                    } else {
+                        throw new \RuntimeException("The content configuration needs either a provider or a property.");
+                    }
+
+                    $relationContentMetadata = new RelationContentMetadata($providerId, $providerMethod);
                     $relationMetadata->setContent($relationContentMetadata);
 
                     if (isset($relationContent['provider_arguments'])) {
                         $relationContentMetadata->setProviderArguments($relationContent['provider_arguments']);
+                    }
+
+                    if (isset($relationContent['property'])) {
+                        $relationContentMetadata->setProviderArguments(array($relationContent['property']));
                     }
 
                     if (isset($relationContent['serializer_type'])) {

--- a/Metadata/Driver/YamlDriver.php
+++ b/Metadata/Driver/YamlDriver.php
@@ -52,8 +52,8 @@ class YamlDriver extends AbstractFileDriver
                         $providerId     = $relationContent['provider_id'];
                         $providerMethod = $relationContent['provider_method'];
                     } elseif (!empty($relationContent['property'])) {
-                        $providerId     = "fsc_hateoas.factory.property";
-                        $providerMethod = "retrieveProperty";
+                        $providerId     = 'fsc_hateoas.factory.identity';
+                        $providerMethod = 'get';
                     } else {
                         throw new \RuntimeException("The content configuration needs either a provider or a property.");
                     }

--- a/README.md
+++ b/README.md
@@ -460,7 +460,6 @@ and `GET /api/users/42/friends` would result in
 </users>
 ```
 
-<<<<<<< HEAD
 ## FormView handler
 
 You can serialize FormView. (Available only in XML, if you need this in JSON, feel try to make a PR :) )
@@ -468,17 +467,10 @@ You can serialize FormView. (Available only in XML, if you need this in JSON, fe
 Telling your client developers to build requests based on forms, has many advantages, and remove some logic from clients.
 It is also really easy to test your api, because you only have to follow links to the form, then use the symfony DomCrawler to
 fill and then submit the form.
-=======
-### Embedding relations from properties
-
-Instead of defining a service to embed resources you can also embed resources, that are properties of your main
-resource.
->>>>>>> Updated README
 
 ```php
 <?php
 
-<<<<<<< HEAD
 class UserController extends Controller
 {
     public function getEditFormAction(User $user)
@@ -514,7 +506,14 @@ class UserController extends Controller
     </select>
 </form>
 ```
-=======
+
+### Embedding relations from properties
+
+Instead of defining a service to embed resources you can also embed resources, that are properties of your main
+resource.
+
+```php
+<?php
 // src/Acme/FooBundle/Entity/User.php
 
 use JMS\SerializerBundle\Annotation as Serializer;
@@ -543,6 +542,3 @@ class User
 ```
 
 This will serialize the `friends` property and embed it as a relation.
-
-
->>>>>>> Updated README

--- a/README.md
+++ b/README.md
@@ -460,6 +460,42 @@ and `GET /api/users/42/friends` would result in
 </users>
 ```
 
+### Embedding relations from properties
+
+Instead of defining a service to embed resources you can also embed resources, that are properties of your main
+resource.
+
+```php
+<?php
+// src/Acme/FooBundle/Entity/User.php
+
+use JMS\SerializerBundle\Annotation as Serializer;
+use FSC\HateoasBundle\Annotation as Rest;
+
+/**
+ * @Rest\Relation("self", href = @Rest\Route("api_user_get", parameters = { "id" = ".id" }))
+ * @Rest\Relation("friends",
+ *     href =  @Rest\Route("api_user_friends_list", parameters = { "id" = ".id" }),
+ *     embed = @Rest\Content(
+ *         property = ".friends"
+ *     )
+ * )
+ *
+ * @Serializer\XmlRoot("user")
+ */
+class User
+{
+    ...
+
+    /**
+     * @var array<User>
+     */
+    private $friends;
+}
+```
+
+This will serialize the `friends` property and embed it as a relation.
+
 ## FormView handler
 
 You can serialize FormView. (Available only in XML, if you need this in JSON, feel try to make a PR :) )
@@ -506,39 +542,3 @@ class UserController extends Controller
     </select>
 </form>
 ```
-
-### Embedding relations from properties
-
-Instead of defining a service to embed resources you can also embed resources, that are properties of your main
-resource.
-
-```php
-<?php
-// src/Acme/FooBundle/Entity/User.php
-
-use JMS\SerializerBundle\Annotation as Serializer;
-use FSC\HateoasBundle\Annotation as Rest;
-
-/**
- * @Rest\Relation("self", href = @Rest\Route("api_user_get", parameters = { "id" = ".id" }))
- * @Rest\Relation("friends",
- *     href =  @Rest\Route("api_user_friends_list", parameters = { "id" = ".id" }),
- *     embed = @Rest\Content(
- *         property = ".friends"
- *     )
- * )
- *
- * @Serializer\XmlRoot("user")
- */
-class User
-{
-    ...
-
-    /**
-     * @var array<User>
-     */
-    private $friends;
-}
-```
-
-This will serialize the `friends` property and embed it as a relation.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,22 @@ class RootController extends Controller
 </root>
 ```
 
+## Json Format
+
+The bundle supports customizing the keys of links and embedded relations when serializing to Json. They are
+controlled by the following configuration:
+
+```yml
+# app/config/config.yml
+
+fsc_hateoas:
+    json:
+        links: _links         # default: links
+        relations: _embedded  # default: relations
+```
+
+The above configuration will result in serialization to valid [hal+json](http://stateless.co/hal_specification.html).
+
 ## Pagerfanta Handler
 
 Default configuration:
@@ -292,7 +308,7 @@ public function getListAction(Request $request, $page = 1, $limit = 10)
 
 Sometimes, your representations have embedded relations that require a service to be fetched, or need to be paginated.
 To embed a relation using this bundle, you create a simple Relation metadata (with an annotation for example),
-and add extra "content" parameters.
+and add extra "content" parameter.
 
 Example:
 
@@ -334,7 +350,7 @@ class UserController extends Controller
 
 ### Model and serializer/hateoas metadata
 
-*Note that you can also configure serializer/hateoas metadatas using yaml to keep serialisation out of your model*
+*Note that you can also configure serializer/hateoas metadata using yaml to keep serialisation out of your model*
 
 ```php
 <?php
@@ -444,6 +460,7 @@ and `GET /api/users/42/friends` would result in
 </users>
 ```
 
+<<<<<<< HEAD
 ## FormView handler
 
 You can serialize FormView. (Available only in XML, if you need this in JSON, feel try to make a PR :) )
@@ -451,10 +468,17 @@ You can serialize FormView. (Available only in XML, if you need this in JSON, fe
 Telling your client developers to build requests based on forms, has many advantages, and remove some logic from clients.
 It is also really easy to test your api, because you only have to follow links to the form, then use the symfony DomCrawler to
 fill and then submit the form.
+=======
+### Embedding relations from properties
+
+Instead of defining a service to embed resources you can also embed resources, that are properties of your main
+resource.
+>>>>>>> Updated README
 
 ```php
 <?php
 
+<<<<<<< HEAD
 class UserController extends Controller
 {
     public function getEditFormAction(User $user)
@@ -490,3 +514,35 @@ class UserController extends Controller
     </select>
 </form>
 ```
+=======
+// src/Acme/FooBundle/Entity/User.php
+
+use JMS\SerializerBundle\Annotation as Serializer;
+use FSC\HateoasBundle\Annotation as Rest;
+
+/**
+ * @Rest\Relation("self", href = @Rest\Route("api_user_get", parameters = { "id" = ".id" }))
+ * @Rest\Relation("friends",
+ *     href =  @Rest\Route("api_user_friends_list", parameters = { "id" = ".id" }),
+ *     embed = @Rest\Content(
+ *         property = ".friends"
+ *     )
+ * )
+ *
+ * @Serializer\XmlRoot("user")
+ */
+class User
+{
+    ...
+
+    /**
+     * @var array<User>
+     */
+    private $friends;
+}
+```
+
+This will serialize the `friends` property and embed it as a relation.
+
+
+>>>>>>> Updated README

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -11,7 +11,7 @@ parameters:
     fsc_hateoas.serializer.handler.form_view.class: FSC\HateoasBundle\Serializer\Handler\FormViewHandler
     fsc_hateoas.serializer.handler.form.class: FSC\HateoasBundle\Serializer\Handler\FormHandler
     fsc_hateoas.json_options: ~
-    fsc_hateoas.factory.property.class: FSC\HateoasBundle\Factory\PropertyFactory
+    fsc_hateoas.factory.identity.class: FSC\HateoasBundle\Factory\IdentityFactory
     fsc_hateoas.event_subscriber.typeparser: ~
 
 services:
@@ -95,5 +95,5 @@ services:
             # Added by DI extension
             #- { name: jms_serializer.subscribing_handler }
 
-    fsc_hateoas.factory.property:
-        class: %fsc_hateoas.factory.property.class%
+    fsc_hateoas.factory.identity:
+        class: %fsc_hateoas.factory.identity.class%

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -76,6 +76,7 @@ services:
             - @fsc_hateoas.serializer.event_subscriber.embedder
             - @fsc_hateoas.serializer.event_subscriber.link
             - true
+            - %fsc_hateoas.json_options%
         tags:
             - { name: jms_serializer.subscribing_handler }
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -10,6 +10,9 @@ parameters:
     fsc_hateoas.serializer.handler.pagerfanta.class: FSC\HateoasBundle\Serializer\Handler\PagerfantaHandler
     fsc_hateoas.serializer.handler.form_view.class: FSC\HateoasBundle\Serializer\Handler\FormViewHandler
     fsc_hateoas.serializer.handler.form.class: FSC\HateoasBundle\Serializer\Handler\FormHandler
+    fsc_hateoas.json_options: ~
+    fsc_hateoas.factory.property.class: FSC\HateoasBundle\Factory\PropertyFactory
+    fsc_hateoas.event_subscriber.typeparser: ~
 
 services:
     fsc_hateoas.serializer.link_serialization_helper:
@@ -50,6 +53,7 @@ services:
         arguments:
             - @fsc_hateoas.factory.link
             - @fsc_hateoas.serializer.link_serialization_helper
+            - %fsc_hateoas.json_options%
         tags:
             - { name: jms_serializer.event_subscriber }
 
@@ -60,6 +64,8 @@ services:
             - @jms_serializer.metadata_factory
             - @fsc_hateoas.metadata.relations_manager
             - @fsc_hateoas.factory.parameters
+            - %fsc_hateoas.event_subscriber.typeparser%
+            - %fsc_hateoas.json_options%
         tags:
             - { name: jms_serializer.event_subscriber }
 
@@ -87,3 +93,6 @@ services:
         tags:
             # Added by DI extension
             #- { name: jms_serializer.subscribing_handler }
+
+    fsc_hateoas.factory.property:
+        class: %fsc_hateoas.factory.property.class%

--- a/Serializer/EventSubscriber/EmbedderEventSubscriber.php
+++ b/Serializer/EventSubscriber/EmbedderEventSubscriber.php
@@ -46,8 +46,8 @@ class EmbedderEventSubscriber implements EventSubscriberInterface
 
     public function __construct(
         ContentFactoryInterface $contentFactory,
-	JMSMetadataFactoryInterface $serializerMetadataFactory,
-	RelationsManagerInterface $relationsManager,
+	    JMSMetadataFactoryInterface $serializerMetadataFactory,
+	    RelationsManagerInterface $relationsManager,
         ParametersFactoryInterface $parametersFactory,
         TypeParser $typeParser = null,
         array $jsonOptions
@@ -97,7 +97,7 @@ class EmbedderEventSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $event->getVisitor()->addData('relations', $relationsData);
+        $event->getVisitor()->addData($this->embeddedCollectionName, $relationsData);
     }
 
     public function getOnPostSerializeData(Event $event)

--- a/Serializer/EventSubscriber/EmbedderEventSubscriber.php
+++ b/Serializer/EventSubscriber/EmbedderEventSubscriber.php
@@ -7,6 +7,7 @@ use JMS\SerializerBundle\Serializer\TypeParser;
 use JMS\SerializerBundle\Serializer\XmlSerializationVisitor;
 use JMS\SerializerBundle\Serializer\EventDispatcher\Events;
 use JMS\SerializerBundle\Serializer\EventDispatcher\Event;
+
 use Metadata\MetadataFactoryInterface as JMSMetadataFactoryInterface;
 use Symfony\Component\Form\Util\PropertyPath;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -127,7 +128,7 @@ class EmbedderEventSubscriber implements EventSubscriberInterface
 
         if (null !== $relationMetadata->getContent()->getSerializerXmlElementName()) {
             $elementName = $relationMetadata->getContent()->getSerializerXmlElementName();
-        } else if (null !== $relationMetadata->getContent()->getSerializerXmlElementRootName()) {
+        } elseif (null !== $relationMetadata->getContent()->getSerializerXmlElementRootName()) {
             $classMetadata = $this->serializerMetadataFactory->getMetadataForClass(get_class($content));
             $elementName = $classMetadata->xmlRootName ?: $elementName;
         }

--- a/Serializer/EventSubscriber/EmbedderEventSubscriber.php
+++ b/Serializer/EventSubscriber/EmbedderEventSubscriber.php
@@ -50,14 +50,14 @@ class EmbedderEventSubscriber implements EventSubscriberInterface
 	    RelationsManagerInterface $relationsManager,
         ParametersFactoryInterface $parametersFactory,
         TypeParser $typeParser = null,
-        array $jsonOptions
+        array $jsonOptions = array()
     ) {
         $this->contentFactory = $contentFactory;
         $this->serializerMetadataFactory = $serializerMetadataFactory;
         $this->relationsManager = $relationsManager;
         $this->parametersFactory = $parametersFactory;
         $this->typeParser = $typeParser ?: new TypeParser();
-        $this->embeddedCollectionName = $jsonOptions['relations'];
+        $this->embeddedCollectionName = !empty($jsonOptions['relations']) ? $jsonOptions['relations'] : 'relations';
     }
 
     public function onPostSerializeXML(Event $event)

--- a/Serializer/EventSubscriber/EmbedderEventSubscriber.php
+++ b/Serializer/EventSubscriber/EmbedderEventSubscriber.php
@@ -46,8 +46,8 @@ class EmbedderEventSubscriber implements EventSubscriberInterface
 
     public function __construct(
         ContentFactoryInterface $contentFactory,
-	    JMSMetadataFactoryInterface $serializerMetadataFactory,
-	    RelationsManagerInterface $relationsManager,
+        JMSMetadataFactoryInterface $serializerMetadataFactory,
+        RelationsManagerInterface $relationsManager,
         ParametersFactoryInterface $parametersFactory,
         TypeParser $typeParser = null,
         array $jsonOptions = array()

--- a/Serializer/EventSubscriber/EmbedderEventSubscriber.php
+++ b/Serializer/EventSubscriber/EmbedderEventSubscriber.php
@@ -41,16 +41,22 @@ class EmbedderEventSubscriber implements EventSubscriberInterface
     protected $relationsManager;
     protected $parametersFactory;
     protected $typeParser;
+    protected $embeddedCollectionName;
 
-    public function __construct(ContentFactoryInterface $contentFactory, JMSMetadataFactoryInterface $serializerMetadataFactory,
-        RelationsManagerInterface $relationsManager, ParametersFactoryInterface $parametersFactory,
-        TypeParser $typeParser = null)
-    {
+    public function __construct(
+        ContentFactoryInterface $contentFactory,
+	JMSMetadataFactoryInterface $serializerMetadataFactory,
+	RelationsManagerInterface $relationsManager,
+        ParametersFactoryInterface $parametersFactory,
+        TypeParser $typeParser = null,
+        array $jsonOptions
+    ) {
         $this->contentFactory = $contentFactory;
         $this->serializerMetadataFactory = $serializerMetadataFactory;
         $this->relationsManager = $relationsManager;
         $this->parametersFactory = $parametersFactory;
         $this->typeParser = $typeParser ?: new TypeParser();
+        $this->embeddedCollectionName = $jsonOptions['relations'];
     }
 
     public function onPostSerializeXML(Event $event)

--- a/Serializer/EventSubscriber/LinkEventSubscriber.php
+++ b/Serializer/EventSubscriber/LinkEventSubscriber.php
@@ -58,7 +58,7 @@ class LinkEventSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $event->getVisitor()->addData('links', $links);
+        $event->getVisitor()->addData($this->linksCollectionName, $links);
     }
 
     public function getOnPostSerializeData(Event $event)
@@ -70,6 +70,5 @@ class LinkEventSubscriber implements EventSubscriberInterface
         $visitor = $event->getVisitor();
 
         return $this->linkSerializationHelper->createGenericLinksData($links, $visitor);
-        // $visitor->addData($this->linksCollectionName, $this->linkSerializationHelper->createGenericLinksData($links, $visitor));
     }
 }

--- a/Serializer/EventSubscriber/LinkEventSubscriber.php
+++ b/Serializer/EventSubscriber/LinkEventSubscriber.php
@@ -5,7 +5,6 @@ namespace FSC\HateoasBundle\Serializer\EventSubscriber;
 use JMS\SerializerBundle\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\SerializerBundle\Serializer\EventDispatcher\Events;
 use JMS\SerializerBundle\Serializer\EventDispatcher\Event;
-use JMS\SerializerBundle\Serializer\TypeParser;
 
 use FSC\HateoasBundle\Factory\LinkFactoryInterface;
 use FSC\HateoasBundle\Serializer\LinkSerializationHelper;

--- a/Serializer/EventSubscriber/LinkEventSubscriber.php
+++ b/Serializer/EventSubscriber/LinkEventSubscriber.php
@@ -35,12 +35,11 @@ class LinkEventSubscriber implements EventSubscriberInterface
     protected $linkSerializationHelper;
     protected $linksCollectionName;
 
-    public function __construct(LinkFactoryInterface $linkFactory, LinkSerializationHelper $linkSerializationHelper, array $jsonOptions)
+    public function __construct(LinkFactoryInterface $linkFactory, LinkSerializationHelper $linkSerializationHelper, array $jsonOptions = array())
     {
         $this->linkFactory = $linkFactory;
         $this->linkSerializationHelper = $linkSerializationHelper;
-        $this->jsonOptions = $jsonOptions;
-        $this->linksCollectionName = $jsonOptions['links'];
+        $this->linksCollectionName = !empty($jsonOptions['links']) ? $jsonOptions['links'] : 'links';
     }
 
     public function onPostSerializeXML(Event $event)

--- a/Serializer/EventSubscriber/LinkEventSubscriber.php
+++ b/Serializer/EventSubscriber/LinkEventSubscriber.php
@@ -34,11 +34,14 @@ class LinkEventSubscriber implements EventSubscriberInterface
 
     protected $linkFactory;
     protected $linkSerializationHelper;
+    protected $linksCollectionName;
 
-    public function __construct(LinkFactoryInterface $linkFactory, LinkSerializationHelper $linkSerializationHelper)
+    public function __construct(LinkFactoryInterface $linkFactory, LinkSerializationHelper $linkSerializationHelper, array $jsonOptions)
     {
         $this->linkFactory = $linkFactory;
         $this->linkSerializationHelper = $linkSerializationHelper;
+        $this->jsonOptions = $jsonOptions;
+        $this->linksCollectionName = $jsonOptions['links'];
     }
 
     public function onPostSerializeXML(Event $event)
@@ -68,5 +71,6 @@ class LinkEventSubscriber implements EventSubscriberInterface
         $visitor = $event->getVisitor();
 
         return $this->linkSerializationHelper->createGenericLinksData($links, $visitor);
+        // $visitor->addData($this->linksCollectionName, $this->linkSerializationHelper->createGenericLinksData($links, $visitor));
     }
 }

--- a/Serializer/Handler/PagerfantaHandler.php
+++ b/Serializer/Handler/PagerfantaHandler.php
@@ -34,15 +34,22 @@ class PagerfantaHandler implements SubscribingHandlerInterface
     protected $embedderEventSubscriber;
     protected $linkEventSubscriber;
     protected $xmlElementsNamesUseSerializerMetadata;
+    protected $linksCollectionName;
+    protected $embeddedCollectionName;
 
-    public function __construct(MetadataFactoryInterface $serializerMetadataFactory,
-        EmbedderEventSubscriber $embedderEventSubscriber, LinkEventSubscriber $linkEventSubscriber,
-        $xmlElementsNamesUseSerializerMetadata = true)
-    {
+    public function __construct(
+        MetadataFactoryInterface $serializerMetadataFactory,
+        EmbedderEventSubscriber $embedderEventSubscriber,
+        LinkEventSubscriber $linkEventSubscriber,
+        $xmlElementsNamesUseSerializerMetadata = true,
+        array $jsonOptions = array()
+    ) {
         $this->serializerMetadataFactory = $serializerMetadataFactory;
         $this->embedderEventSubscriber = $embedderEventSubscriber;
         $this->linkEventSubscriber = $linkEventSubscriber;
         $this->xmlElementsNamesUseSerializerMetadata = $xmlElementsNamesUseSerializerMetadata;
+        $this->linksCollectionName = $jsonOptions['links'];
+        $this->embeddedCollectionName = $jsonOptions['relations'];
     }
 
     public function serializeToXML(XmlSerializationVisitor $visitor, Pagerfanta $pager, array $type)
@@ -95,11 +102,11 @@ class PagerfantaHandler implements SubscribingHandlerInterface
         );
 
         if (null !== ($links = $this->linkEventSubscriber->getOnPostSerializeData(new Event($visitor, $pager, $type)))) {
-            $data['links'] = $links;
+            $data[$this->linksCollectionName] = $links;
         }
 
         if (null !== ($relations = $this->embedderEventSubscriber->getOnPostSerializeData(new Event($visitor, $pager, $type)))) {
-            $data['relations'] = $relations;
+            $data[$this->embeddedCollectionName] = $relations;
         }
 
         return $data;

--- a/Tests/Fixtures/User.php
+++ b/Tests/Fixtures/User.php
@@ -22,11 +22,16 @@ use FSC\HateoasBundle\Annotation as Rest;
  *          serializerXmlElementName = "favorites"
  *     )
  * )
+ * @Rest\Relation("disclosure",
+ *     href = @Rest\Route("homepage"),
+ *     embed = @Rest\Content(property = ".property")
+ * )
  */
 class User
 {
     private $id;
     private $username;
+    private $property;
 
     public function setId($id)
     {

--- a/Tests/Functional/ControllerTest.php
+++ b/Tests/Functional/ControllerTest.php
@@ -198,20 +198,19 @@ XML
         $client->request('GET', '/api/posts/2?_format=json');
 
         $response = $client->getResponse(); /**  */
+        $expected = array(
+          'id' => 2,
+          'title' => "How to create awesome symfony2 application",
+          '_links' => array(
+            array(
+              'rel' => 'self',
+              'href' => 'http:\/\/localhost\/api\/posts\/2'
+            )
+          )
+        );
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertSerializedJsonEquals('
-          {
-            "id":"2",
-            "title":"How to create awesome symfony2 application",
-            "_links":[
-              {
-                "rel":"self",
-                "href":"http:\/\/localhost\/api\/posts\/2"
-              }
-            ]
-          }',
-          $response->getContent()
-        );
+        $unserialized = json_decode($response->getContent());
+        $this->assertEquals($expected, $unserialized);
     }
 }

--- a/Tests/Functional/ControllerTest.php
+++ b/Tests/Functional/ControllerTest.php
@@ -199,11 +199,11 @@ XML
 
         $response = $client->getResponse(); /**  */
         $expected = array(
-          'id' => 2,
-          'title' => "How to create awesome symfony2 application",
+          'id'     => 2,
+          'title'  => "How to create awesome symfony2 application",
           '_links' => array(
             array(
-              'rel' => 'self',
+              'rel'  => 'self',
               'href' => 'http:\/\/localhost\/api\/posts\/2'
             )
           )

--- a/Tests/Functional/ControllerTest.php
+++ b/Tests/Functional/ControllerTest.php
@@ -297,7 +297,7 @@ XML
                     ),
                   ),
                 ),
-                'links' => array(
+                '_links' => array(
                   array(
                     'rel'  => 'self',
                     'href' => 'http://localhost/api/users/1/posts?limit=1&page=1'

--- a/Tests/Functional/ControllerTest.php
+++ b/Tests/Functional/ControllerTest.php
@@ -191,4 +191,27 @@ XML
 XML
             , $response->getContent());
     }
+
+    public function testGetPostJsonHal()
+    {
+        $client = $this->createClient(array('env' => 'hal'));
+        $client->request('GET', '/api/posts/2?_format=json');
+
+        $response = $client->getResponse(); /**  */
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSerializedJsonEquals('
+          {
+            "id":"2",
+            "title":"How to create awesome symfony2 application",
+            "_links":[
+              {
+                "rel":"self",
+                "href":"http:\/\/localhost\/api\/posts\/2"
+              }
+            ]
+          }',
+          $response->getContent()
+        );
+    }
 }

--- a/Tests/Functional/ControllerTest.php
+++ b/Tests/Functional/ControllerTest.php
@@ -197,20 +197,130 @@ XML
         $client = $this->createClient(array('env' => 'hal'));
         $client->request('GET', '/api/posts/2?_format=json');
 
-        $response = $client->getResponse(); /**  */
+        $response = $client->getResponse();
+        $unserialized = (array) json_decode($response->getContent(), true);
+
         $expected = array(
-          'id'     => 2,
+          'id'     => '2',
           'title'  => "How to create awesome symfony2 application",
           '_links' => array(
             array(
               'rel'  => 'self',
-              'href' => 'http:\/\/localhost\/api\/posts\/2'
+              'href' => 'http://localhost/api/posts/2'
             )
           )
         );
 
         $this->assertEquals(200, $response->getStatusCode());
-        $unserialized = json_decode($response->getContent());
+        $this->assertEquals($expected, $unserialized);
+    }
+
+    public function testGetRelationsJsonHal()
+    {
+        $client = $this->createClient(array('env' => 'hal'));
+        $client->request('GET', '/api/mixed?_format=json');
+
+        $response = $client->getResponse();
+        $unserialized = (array) json_decode($response->getContent(), true);
+
+        $expected = array(
+          array(
+            'id'     => '1',
+            'title'  => "Welcome on the blog!",
+            '_links' => array(
+              array(
+                'rel'  => 'self',
+                'href' => 'http://localhost/api/posts/1'
+              )
+            )
+          ),
+          array(
+            'id'     => '2',
+            'title'  => "How to create awesome symfony2 application",
+            '_links' => array(
+              array(
+                'rel'  => 'self',
+                'href' => 'http://localhost/api/posts/2'
+              )
+            )
+          ),
+          array(
+            'id' => 1,
+            'first_name' => 'Adrien',
+            'last_name' => 'Brault',
+            '_links' => array(
+              array(
+                'rel'  => 'self',
+                'href' => 'http://localhost/api/users/1'
+              ),
+              array(
+                'rel'  => 'alternate',
+                'href' => 'http://localhost/profile/1'
+              ),
+              array(
+                'rel'  => 'users',
+                'href' => 'http://localhost/api/users'
+              ),
+              array(
+                'rel'  => 'last-post',
+                'href' => 'http://localhost/api/users/1/last-post'
+              ),
+              array(
+                'rel'  => 'posts',
+                'href' => 'http://localhost/api/users/1/posts'
+              ),
+            ),
+            '_embedded' => array(
+              'last-post' => array(
+                'id'     => '2',
+                'title'  => "How to create awesome symfony2 application",
+                '_links' => array(
+                  array(
+                    'rel'  => 'self',
+                    'href' => 'http://localhost/api/posts/2'
+                  )
+                ),
+              ),
+              'posts' => array(
+                'page'    => 1,
+                'limit'   => 1,
+                'total'   => 2,
+                'results' => array(
+                  array(
+                    'id'     => '2',
+                    'title'  => "How to create awesome symfony2 application",
+                    '_links' => array(
+                      array(
+                        'rel'  => 'self',
+                        'href' => 'http://localhost/api/posts/2'
+                      )
+                    ),
+                  ),
+                ),
+                'links' => array(
+                  array(
+                    'rel'  => 'self',
+                    'href' => 'http://localhost/api/users/1/posts?limit=1&page=1'
+                  ),
+                  array(
+                    'rel'  => 'first',
+                    'href' => 'http://localhost/api/users/1/posts?limit=1&page=1'
+                  ),
+                  array(
+                    'rel'  => 'last',
+                    'href' => 'http://localhost/api/users/1/posts?limit=1&page=2'
+                  ),
+                  array(
+                    'rel'  => 'next',
+                    'href' => 'http://localhost/api/users/1/posts?limit=1&page=2'
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals($expected, $unserialized);
     }
 }

--- a/Tests/Functional/config/config_hal.yml
+++ b/Tests/Functional/config/config_hal.yml
@@ -1,0 +1,8 @@
+imports:
+    - { resource: config_test.yml }
+
+# Hateoas Bundle Hal+Json configuration
+fsc_hateoas:
+    json:
+        links: _links
+        relations: _embedded

--- a/Tests/Metadata/Builder/RelationsBuilderTest.php
+++ b/Tests/Metadata/Builder/RelationsBuilderTest.php
@@ -110,8 +110,8 @@ class RelationBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $relationsMetadata);
 
         $this->assertInstanceOf('FSC\HateoasBundle\Metadata\RelationContentMetadataInterface', $relationsMetadata[0]->getContent());
-        $this->assertEquals('fsc_hateoas.factory.property', $relationsMetadata[0]->getContent()->getProviderId());
-        $this->assertEquals('retrieveProperty', $relationsMetadata[0]->getContent()->getProviderMethod());
+        $this->assertEquals('fsc_hateoas.factory.identity', $relationsMetadata[0]->getContent()->getProviderId());
+        $this->assertEquals('get', $relationsMetadata[0]->getContent()->getProviderMethod());
         $this->assertEquals(array('.someProperty'), $relationsMetadata[0]->getContent()->getProviderArguments());
         $this->assertEquals($xmlName, $relationsMetadata[0]->getContent()->getSerializerXmlElementName());
         $this->assertEquals($xmlRootMetadata, $relationsMetadata[0]->getContent()->getSerializerXmlElementRootName());

--- a/Tests/Metadata/Builder/RelationsBuilderTest.php
+++ b/Tests/Metadata/Builder/RelationsBuilderTest.php
@@ -90,4 +90,30 @@ class RelationBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($xmlName, $relationsMetadata[0]->getContent()->getSerializerXmlElementName());
         $this->assertEquals($xmlRootMetadata, $relationsMetadata[0]->getContent()->getSerializerXmlElementRootName());
     }
+
+    public function testAddEmbeddedRelationProperty()
+    {
+        $RelationsMetadataBuilder = new RelationsMetadataBuilder();
+
+        $RelationsMetadataBuilder->add('self',
+            array(
+                'route' => '_some_route',
+            ), array(
+                'property' => '.someProperty',
+                'serializerType' => 'array<Foo>',
+                'serializerXmlElementName' => $xmlName = 'users',
+                'serializerXmlElementRootMetadata' => $xmlRootMetadata = true,
+            )
+        );
+
+        $relationsMetadata = $RelationsMetadataBuilder->build();
+        $this->assertInternalType('array', $relationsMetadata);
+
+        $this->assertInstanceOf('FSC\HateoasBundle\Metadata\RelationContentMetadataInterface', $relationsMetadata[0]->getContent());
+        $this->assertEquals('fsc_hateoas.factory.property', $relationsMetadata[0]->getContent()->getProviderId());
+        $this->assertEquals('retrieveProperty', $relationsMetadata[0]->getContent()->getProviderMethod());
+        $this->assertEquals(array('.someProperty'), $relationsMetadata[0]->getContent()->getProviderArguments());
+        $this->assertEquals($xmlName, $relationsMetadata[0]->getContent()->getSerializerXmlElementName());
+        $this->assertEquals($xmlRootMetadata, $relationsMetadata[0]->getContent()->getSerializerXmlElementRootName());
+    }
 }

--- a/Tests/Metadata/Builder/RelationsBuilderTest.php
+++ b/Tests/Metadata/Builder/RelationsBuilderTest.php
@@ -93,7 +93,7 @@ class RelationBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testAddEmbeddedRelationProperty()
     {
-        $RelationsMetadataBuilder = new RelationsMetadataBuilder();
+        $RelationsMetadataBuilder = new RelationsBuilder();
 
         $RelationsMetadataBuilder->add('self',
             array(

--- a/Tests/Metadata/Driver/CommonDriverTest.php
+++ b/Tests/Metadata/Driver/CommonDriverTest.php
@@ -121,8 +121,8 @@ class CommonDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('disclosure', $relationMetadata->getRel());
         $this->assertEquals('homepage', $relationMetadata->getRoute());
         $this->assertInstanceOf('FSC\HateoasBundle\Metadata\RelationContentMetadataInterface', $relationMetadata->getContent());
-        $this->assertEquals('fsc_hateoas.factory.property', $relationMetadata->getContent()->getProviderId());
-        $this->assertEquals('retrieveProperty', $relationMetadata->getContent()->getProviderMethod());
+        $this->assertEquals('fsc_hateoas.factory.identity', $relationMetadata->getContent()->getProviderId());
+        $this->assertEquals('get', $relationMetadata->getContent()->getProviderMethod());
         $this->assertEquals(array('.property'), $relationMetadata->getContent()->getProviderArguments());
 
 return;

--- a/Tests/Metadata/Driver/CommonDriverTest.php
+++ b/Tests/Metadata/Driver/CommonDriverTest.php
@@ -114,6 +114,17 @@ class CommonDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Pagerfanta<custom>', $relationMetadata->getContent()->getSerializerType());
         $this->assertEquals('favorites', $relationMetadata->getContent()->getSerializerXmlElementName());
         $this->assertFalse($relationMetadata->getContent()->getSerializerXmlElementRootName());
+
+        $n++;
+
+        $relationMetadata = $relationsMetadata[$n];
+        $this->assertEquals('disclosure', $relationMetadata->getRel());
+        $this->assertEquals('homepage', $relationMetadata->getRoute());
+        $this->assertInstanceOf('FSC\HateoasBundle\Metadata\RelationContentMetadataInterface', $relationMetadata->getContent());
+        $this->assertEquals('fsc_hateoas.factory.property', $relationMetadata->getContent()->getProviderId());
+        $this->assertEquals('retrieveProperty', $relationMetadata->getContent()->getProviderMethod());
+        $this->assertEquals(array('.property'), $relationMetadata->getContent()->getProviderArguments());
+
 return;
     }
 }

--- a/Tests/Metadata/Driver/yml/User.yml
+++ b/Tests/Metadata/Driver/yml/User.yml
@@ -29,3 +29,8 @@ FSC\HateoasBundle\Tests\Fixtures\User:
               provider_arguments: [ id, =3 ]
               serializer_type: Pagerfanta<custom>
               serializer_xml_element_name: favorites
+        - rel: disclosure
+          href:
+            route: homepage
+          content:
+            property: .property


### PR DESCRIPTION
## Configuration required to serialize to hal+ json

Added the ability to specify what the keys in the json serialization is for links and relations. That way, proper hal+json serialization is possible.
## Property based relation embedding

Added a property factory that allows to make properties embedded relations. This avoids having to create services.

Please let me know if you want me to add anything. Thanks.

_Note_: This is a reopened PR (https://github.com/TheFootballSocialClub/FSCHateoasBundle/pull/8) which was based off of the `dev` branch. When that branch was deleted, the PR was closed. 

Please let me know when you are happy with the code here, then I can squash the commits down to 1. 
