### PR TITLE
Can now add extra parameters to all route generation

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -42,6 +42,7 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('relations_key')->defaultValue('relations')->end()
                 ->end()
             ->end()
+            ->scalarNode('absolute_url')->defaultValue(true)->end()
         ;
 
         $this->addMetadataSection($root);

--- a/DependencyInjection/FSCHateoasExtension.php
+++ b/DependencyInjection/FSCHateoasExtension.php
@@ -37,6 +37,9 @@ class FSCHateoasExtension extends ConfigurableExtension
         $container->setParameter('fsc_hateoas.json.links_key', $config['json']['links_key']);
         $container->setParameter('fsc_hateoas.json.relations_key', $config['json']['relations_key']);
 
+        $urlGeneratorDefinition = $container->getDefinition('fsc_hateoas.routing.generator');
+        $urlGeneratorDefinition->addMethodCall('setForceAbsolute', array($config['absolute_url']));
+
         $this->configureMetadata($config, $container);
     }
 

--- a/Factory/AbstractLinkFactory.php
+++ b/Factory/AbstractLinkFactory.php
@@ -28,6 +28,6 @@ abstract class AbstractLinkFactory
     {
         ksort($parameters); // Have consistent url query strings, for the tests
 
-        return $this->urlGenerator->generate($name, $parameters, true);
+        return $this->urlGenerator->generate($name, $parameters);
     }
 }

--- a/Factory/FormViewFactory.php
+++ b/Factory/FormViewFactory.php
@@ -23,7 +23,7 @@ class FormViewFactory
 
         $formView->vars['attr'] = array(
             'method' => strtoupper($method),
-            'action' => $this->urlGenerator->generate($route, $routeParameters, true),
+            'action' => $this->urlGenerator->generate($route, $routeParameters),
         );
 
         return $formView;

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -11,6 +11,7 @@ parameters:
     fsc_hateoas.serializer.handler.form_view.class: FSC\HateoasBundle\Serializer\Handler\FormViewHandler
     fsc_hateoas.serializer.handler.form.class: FSC\HateoasBundle\Serializer\Handler\FormHandler
     fsc_hateoas.factory.identity.class: FSC\HateoasBundle\Factory\IdentityFactory
+    fsc_hateoas.routing.generator.class: FSC\HateoasBundle\Routing\UrlGenerator
 
     fsc_hateoas.json.links_key: ~
     fsc_hateoas.json.relations_key: ~
@@ -24,7 +25,7 @@ services:
         class: %fsc_hateoas.factory.link.class%
         public: false
         arguments:
-            - @router
+            - @fsc_hateoas.routing.generator
             - @fsc_hateoas.metadata.factory
             - @fsc_hateoas.factory.parameters
 
@@ -43,7 +44,7 @@ services:
     fsc_hateoas.factory.form_view:
         class: %fsc_hateoas.factory.form_view.class%
         arguments:
-            - @router
+            - @fsc_hateoas.routing.generator
             - @form.factory
 
     fsc_hateoas.serializer.xml_form_view:
@@ -99,3 +100,8 @@ services:
 
     fsc_hateoas.factory.identity:
         class: %fsc_hateoas.factory.identity.class%
+
+    fsc_hateoas.routing.generator:
+        class: %fsc_hateoas.routing.generator.class%
+        arguments:
+            - @router

--- a/Routing/UrlGenerator.php
+++ b/Routing/UrlGenerator.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace FSC\HateoasBundle\Routing;
+
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RequestContext;
+
+class UrlGenerator implements UrlGeneratorInterface
+{
+    private $wrappedUrlGenerator;
+    private $extraParameters;
+    private $forceAbsolute;
+
+    public function __construct(UrlGeneratorInterface $urlGenerator, $forceAbsolute = false)
+    {
+        $this->wrappedUrlGenerator = $urlGenerator;
+        $this->extraParameters = array();
+        $this->forceAbsolute = $forceAbsolute;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContext(RequestContext $context)
+    {
+        return $this->wrappedUrlGenerator->setContext($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContext()
+    {
+        return $this->wrappedUrlGenerator->getContext();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generate($name, $parameters = array(), $absolute = false)
+    {
+        $parameters = array_merge($this->extraParameters, $parameters);
+
+        if ($this->forceAbsolute) {
+            $absolute = true;
+        }
+
+        return $this->wrappedUrlGenerator->generate($name, $parameters, $absolute);
+    }
+
+    public function setForceAbsolute($forceAbsolute)
+    {
+        $this->forceAbsolute = $forceAbsolute;
+    }
+
+    public function setExtraParameters(array $extraParameters)
+    {
+        $this->extraParameters = $extraParameters;
+    }
+
+    public function getExtraParameters()
+    {
+        return $this->extraParameters;
+    }
+
+    public function getForceAbsolute()
+    {
+        return $this->forceAbsolute;
+    }
+}

--- a/Tests/Factory/LinkFactoryTest.php
+++ b/Tests/Factory/LinkFactoryTest.php
@@ -34,7 +34,7 @@ class LinkFactoryTest extends \PHPUnit_Framework_TestCase
         $urlGenerator
             ->expects($this->once())
             ->method('generate')
-            ->with($route, array('identifier' => $id), true)
+            ->with($route, array('identifier' => $id))
             ->will($this->returnValue($href = 'http://foo.com'))
         ;
 

--- a/Tests/Functional/ControllerTest.php
+++ b/Tests/Functional/ControllerTest.php
@@ -126,6 +126,25 @@ XML
         , $response->getContent());
     }
 
+    public function testGetCreatePostWithFormatInLinksFormXml()
+    {
+        $client = $this->createClient();
+        $client->request('GET', '/api/posts/create_format?_format=xml');
+
+        $response = $client->getResponse(); /** @var $response Response */
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<form method="POST" action="http://localhost/api/posts?_format=xml">
+  <link rel="self" href="http://localhost/api/posts/create_format?_format=xml"/>
+  <input type="text" name="post[title]" required="required"/>
+</form>
+
+XML
+            , $response->getContent());
+    }
+
     public function testListPostsXml()
     {
         $client = $this->createClient();

--- a/Tests/Functional/TestBundle/Controller/PostController.php
+++ b/Tests/Functional/TestBundle/Controller/PostController.php
@@ -37,4 +37,13 @@ class PostController extends Controller
 
         return new Response($this->get('serializer')->serialize($formView, $request->get('_format')));
     }
+
+    public function getCreateFormatPostFormAction(Request $request)
+    {
+        $this->get('fsc_hateoas.routing.generator')->setExtraParameters(array(
+            '_format' => $request->get('_format'),
+        ));
+
+        return $this->getCreatePostFormAction($request);
+    }
 }

--- a/Tests/Functional/config/routing.yml
+++ b/Tests/Functional/config/routing.yml
@@ -13,6 +13,11 @@ api_user_list:
 api_user_lastpost_get:
     pattern: /api/users/{id}/last-post
 
+api_post_create_format_form:
+    pattern: /api/posts/create_format
+    defaults:
+        _controller: TestBundle:Post:getCreateFormatPostForm
+
 api_post_create_form:
     pattern: /api/posts/create
     defaults:


### PR DESCRIPTION
Created a wrapper around the original url generator, this allow us to:
- Add extra route parameters to all url generation (_format, version etc)
- Choose in the configuration wheter all links should be absolute or not

This should fix #9 cc @lsmith77 @hutchic
