### PR TITLE
Update README for links

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,16 +98,13 @@ or
 {
     "id": 24,
     "links": [
-        {
-            "rel": "self",
+        "self": {
             "href": "http:\/\/localhost\/api\/users\/24"
         },
-        {
-            "rel": "alternate",
+        "alternate": {
             "href": "http:\/\/localhost\/profile\/24"
         },
-        {
-            "rel": "users",
+        "users": {
             "href": "http:\/\/localhost\/api\/users"
         }
     ]


### PR DESCRIPTION
After the change to the way links are serialized (keyed by the rel), the README still had it the old way.
