### PR TITLE
Added query params to generated links

### DIFF
--- a/Metadata/RelationsManager.php
+++ b/Metadata/RelationsManager.php
@@ -75,12 +75,7 @@ class RelationsManager implements RelationsManagerInterface
     {
         $request       = $this->container->get('request');
 
-        $routeParams   = $request->attributes->get('_route_params');
-        $queryParams   = $request->query->all();
-
-        $requestParams = array_merge($routeParams, $queryParams);
-
-        return $requestParams;
+        return array_merge($request->attributes->get('_route_params'), $request->query->all());
     }
 
     protected function createPagerNavigationRelations(PagerfantaInterface $pager, $route, $routeParameters = array(), $pageParameterName = null, $limitParameterName = null)

--- a/Metadata/RelationsManager.php
+++ b/Metadata/RelationsManager.php
@@ -73,7 +73,14 @@ class RelationsManager implements RelationsManagerInterface
 
     protected function getRequestParameters()
     {
-        return $this->container->get('request')->attributes->get('_route_params');
+        $request       = $this->container->get('request');
+
+        $routeParams   = $request->attributes->get('_route_params');
+        $queryParams   = $request->query->all();
+
+        $requestParams = array_merge($routeParams, $queryParams);
+
+        return $requestParams;
     }
 
     protected function createPagerNavigationRelations(PagerfantaInterface $pager, $route, $routeParameters = array(), $pageParameterName = null, $limitParameterName = null)

--- a/Tests/Functional/ControllerTest.php
+++ b/Tests/Functional/ControllerTest.php
@@ -39,9 +39,9 @@ XML
         $this->assertEquals(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <collection page="1" limit="10" total="2">
-  <link rel="self" href="http://localhost/api/users/42/posts?limit=10&amp;page=1"/>
-  <link rel="first" href="http://localhost/api/users/42/posts?limit=10&amp;page=1"/>
-  <link rel="last" href="http://localhost/api/users/42/posts?limit=10&amp;page=1"/>
+  <link rel="self" href="http://localhost/api/users/42/posts?_format=xml&amp;limit=10&amp;page=1"/>
+  <link rel="first" href="http://localhost/api/users/42/posts?_format=xml&amp;limit=10&amp;page=1"/>
+  <link rel="last" href="http://localhost/api/users/42/posts?_format=xml&amp;limit=10&amp;page=1"/>
   <post id="2">
     <title><![CDATA[How to create awesome symfony2 application]]></title>
     <link rel="self" href="http://localhost/api/posts/2"/>
@@ -67,9 +67,9 @@ XML
         $this->assertEquals(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <collection page="1" limit="10" total="2">
-  <link rel="self" href="http://localhost/api/users/42/posts?pagination%5Blimit%5D=10&amp;pagination%5Bpage%5D=1"/>
-  <link rel="first" href="http://localhost/api/users/42/posts?pagination%5Blimit%5D=10&amp;pagination%5Bpage%5D=1"/>
-  <link rel="last" href="http://localhost/api/users/42/posts?pagination%5Blimit%5D=10&amp;pagination%5Bpage%5D=1"/>
+  <link rel="self" href="http://localhost/api/users/42/posts?_format=xml&amp;pagination%5Blimit%5D=10&amp;pagination%5Bpage%5D=1"/>
+  <link rel="first" href="http://localhost/api/users/42/posts?_format=xml&amp;pagination%5Blimit%5D=10&amp;pagination%5Bpage%5D=1"/>
+  <link rel="last" href="http://localhost/api/users/42/posts?_format=xml&amp;pagination%5Blimit%5D=10&amp;pagination%5Bpage%5D=1"/>
   <post id="2">
     <title><![CDATA[How to create awesome symfony2 application]]></title>
     <link rel="self" href="http://localhost/api/posts/2"/>
@@ -118,7 +118,7 @@ XML
         $this->assertEquals(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <form method="POST" action="http://localhost/api/posts">
-  <link rel="self" href="http://localhost/api/posts/create"/>
+  <link rel="self" href="http://localhost/api/posts/create?_format=xml"/>
   <input type="text" name="post[title]" required="required"/>
 </form>
 
@@ -156,9 +156,9 @@ XML
         $this->assertEquals(<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <posts page="1" limit="10" total="3">
-  <link rel="self" href="http://localhost/api/posts?limit=10&amp;page=1"/>
-  <link rel="first" href="http://localhost/api/posts?limit=10&amp;page=1"/>
-  <link rel="last" href="http://localhost/api/posts?limit=10&amp;page=1"/>
+  <link rel="self" href="http://localhost/api/posts?_format=xml&amp;limit=10&amp;page=1"/>
+  <link rel="first" href="http://localhost/api/posts?_format=xml&amp;limit=10&amp;page=1"/>
+  <link rel="last" href="http://localhost/api/posts?_format=xml&amp;limit=10&amp;page=1"/>
   <post id="1">
     <title><![CDATA[Welcome on the blog!]]></title>
     <link rel="self" href="http://localhost/api/posts/1"/>


### PR DESCRIPTION
This is so that pagination also works with a route such as `/search?q=bla`
