### PR TITLE
Added support for non-required relations (fixes #21)

### DIFF
--- a/Annotation/Relation.php
+++ b/Annotation/Relation.php
@@ -24,4 +24,9 @@ final class Relation
      * @var \FSC\HateoasBundle\Annotation\Content
      */
     public $embed;
+
+    /**
+     * @var Boolean
+     */
+    public $required = true;
 }

--- a/Annotation/Route.php
+++ b/Annotation/Route.php
@@ -19,4 +19,9 @@ final class Route
      * @var array
      */
     public $parameters;
+
+    /**
+     * @var Boolean
+     */
+    public $required = true;
 }

--- a/Annotation/Route.php
+++ b/Annotation/Route.php
@@ -19,9 +19,4 @@ final class Route
      * @var array
      */
     public $parameters;
-
-    /**
-     * @var Boolean
-     */
-    public $required = true;
 }

--- a/Factory/LinkFactory.php
+++ b/Factory/LinkFactory.php
@@ -4,6 +4,7 @@ namespace FSC\HateoasBundle\Factory;
 
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Form\Util\PropertyPath;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 use FSC\HateoasBundle\Model\Link;
 use FSC\HateoasBundle\Metadata\MetadataFactoryInterface;
@@ -42,7 +43,13 @@ class LinkFactory extends AbstractLinkFactory implements LinkFactoryInterface
         $links = array();
 
         foreach ($classMetadata->getRelations() as $relationMetadata) {
-            $links[] = $this->createLinkFromMetadata($relationMetadata, $object);
+            try {
+                $links[] = $this->createLinkFromMetadata($relationMetadata, $object);
+            } catch (UnexpectedTypeException $e) {
+                if ($relationMetadata->isRequired()) {
+                    throw $e;
+                }
+            }
         }
 
         return $links;

--- a/Metadata/Builder/RelationsBuilder.php
+++ b/Metadata/Builder/RelationsBuilder.php
@@ -17,7 +17,7 @@ class RelationsBuilder implements RelationsBuilderInterface
         $this->relationsMetadata = array();
     }
 
-    public function add($rel, $href, array $embed = null)
+    public function add($rel, $href, array $embed = null, $required = true)
     {
         $relationMetadata = new RelationMetadata($rel);
 
@@ -78,6 +78,8 @@ class RelationsBuilder implements RelationsBuilderInterface
 
             $relationMetadata->setContent($contentMetadata);
         }
+
+        $relationMetadata->setRequired($required);
 
         $this->relationsMetadata[] = $relationMetadata;
     }

--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -79,6 +79,10 @@ class AnnotationDriver implements DriverInterface
                     }
                 }
 
+                if (false === $annotation->required) {
+                    $relationMetadata->setRequired(false);
+                }
+
                 $classMetadata->addRelation($relationMetadata);
             }
         }

--- a/Metadata/Driver/YamlDriver.php
+++ b/Metadata/Driver/YamlDriver.php
@@ -84,6 +84,10 @@ class YamlDriver extends AbstractFileDriver
                     }
                 }
 
+                if (isset($relation['required']) && false === $relation['required']) {
+                    $relationMetadata->setRequired(false);
+                }
+
                 $classMetadata->addRelation($relationMetadata);
             }
         }

--- a/Metadata/RelationMetadata.php
+++ b/Metadata/RelationMetadata.php
@@ -9,6 +9,7 @@ class RelationMetadata implements RelationMetadataInterface
     private $route;
     private $params;
     private $content;
+    private $required = true;
 
     public function __construct($rel)
     {
@@ -79,5 +80,21 @@ class RelationMetadata implements RelationMetadataInterface
     public function getUrl()
     {
         return $this->url;
+    }
+
+    /**
+     * @param Boolean $required
+     */
+    public function setRequired($required)
+    {
+        $this->required = $required;
+    }
+
+    /**
+     * @return Boolean
+     */
+    public function isRequired()
+    {
+        return $this->required;
     }
 }

--- a/Metadata/RelationMetadataInterface.php
+++ b/Metadata/RelationMetadataInterface.php
@@ -28,4 +28,9 @@ interface RelationMetadataInterface
      * @return null|RelationContentMetadataInterface
      */
     public function getContent();
+
+    /**
+     * @return Boolean
+     */
+    public function isRequired();
 }

--- a/Metadata/RelationsManager.php
+++ b/Metadata/RelationsManager.php
@@ -58,10 +58,10 @@ class RelationsManager implements RelationsManagerInterface
         $this->metadataFactory->addObjectRelations($object, $relations);
     }
 
-    public function addRelation($object, $rel, $href, array $embed = null)
+    public function addRelation($object, $rel, $href, array $embed = null, $required = true)
     {
         $relationsBuilder = $this->relationsBuilderFactory->create();
-        $relationsBuilder->add($rel, $href, $embed);
+        $relationsBuilder->add($rel, $href, $embed, $required);
 
         $this->metadataFactory->addObjectRelations($object, $relationsBuilder->build());
     }

--- a/Tests/Fixtures/User.php
+++ b/Tests/Fixtures/User.php
@@ -29,12 +29,17 @@ use FSC\HateoasBundle\Annotation as Rest;
  * @Rest\Relation("adrienbrault",
  *     href = "http://adrienbrault.fr"
  * )
+ * @Rest\Relation("best_friend",
+ *     href     = @Rest\Route("_some_route", parameters = { "id" = "bestFriend.id" }),
+ *     required = false
+ * )
  */
 class User
 {
     private $id;
     private $username;
     private $property;
+    private $bestFriend;
 
     public function setId($id)
     {
@@ -54,5 +59,15 @@ class User
     public function getUsername()
     {
         return $this->username;
+    }
+
+    public function setBestFriend(User $user)
+    {
+        $this->bestFriend = $user;
+    }
+
+    public function getBestFriend()
+    {
+        return $this->bestFriend;
     }
 }

--- a/Tests/Metadata/Driver/CommonDriverTest.php
+++ b/Tests/Metadata/Driver/CommonDriverTest.php
@@ -63,6 +63,7 @@ class CommonDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('_some_route', $relationMetadata->getRoute());
         $this->assertEquals(array('identifier' => 'id'), $relationMetadata->getParams());
         $this->assertNull($relationMetadata->getContent());
+        $this->assertTrue($relationMetadata->isRequired());
 
         $n++;
 
@@ -71,6 +72,7 @@ class CommonDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('_some_route2', $relationMetadata->getRoute());
         $this->assertEquals(array(), $relationMetadata->getParams());
         $this->assertNull($relationMetadata->getContent());
+        $this->assertTrue($relationMetadata->isRequired());
 
         $n++;
 
@@ -79,6 +81,7 @@ class CommonDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('_some_route3', $relationMetadata->getRoute());
         $this->assertEquals(array(), $relationMetadata->getParams());
         $this->assertNull($relationMetadata->getContent());
+        $this->assertTrue($relationMetadata->isRequired());
 
         $n++;
 
@@ -100,6 +103,7 @@ class CommonDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($relationMetadata->getContent()->getSerializerType());
         $this->assertNull($relationMetadata->getContent()->getSerializerXmlElementName());
         $this->assertTrue($relationMetadata->getContent()->getSerializerXmlElementRootName());
+        $this->assertTrue($relationMetadata->isRequired());
 
         $n++;
 
@@ -114,6 +118,7 @@ class CommonDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Pagerfanta<custom>', $relationMetadata->getContent()->getSerializerType());
         $this->assertEquals('favorites', $relationMetadata->getContent()->getSerializerXmlElementName());
         $this->assertTrue($relationMetadata->getContent()->getSerializerXmlElementRootName());
+        $this->assertTrue($relationMetadata->isRequired());
 
         $n++;
 
@@ -124,6 +129,7 @@ class CommonDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('fsc_hateoas.factory.identity', $relationMetadata->getContent()->getProviderId());
         $this->assertEquals('get', $relationMetadata->getContent()->getProviderMethod());
         $this->assertEquals(array('.property'), $relationMetadata->getContent()->getProviderArguments());
+        $this->assertTrue($relationMetadata->isRequired());
 
         $n++;
 
@@ -132,5 +138,15 @@ class CommonDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://adrienbrault.fr', $relationMetadata->getUrl());
         $this->assertNull($relationMetadata->getRoute());
         $this->assertNull($relationMetadata->getContent());
+        $this->assertTrue($relationMetadata->isRequired());
+
+        $n++;
+
+        $relationMetadata = $relationsMetadata[$n];
+        $this->assertEquals('best_friend', $relationMetadata->getRel());
+        $this->assertEquals('_some_route', $relationMetadata->getRoute());
+        $this->assertEquals(array('id' => 'bestFriend.id'), $relationMetadata->getParams());
+        $this->assertNull($relationMetadata->getContent());
+        $this->assertFalse($relationMetadata->isRequired());
     }
 }

--- a/Tests/Metadata/Driver/yml/User.yml
+++ b/Tests/Metadata/Driver/yml/User.yml
@@ -38,3 +38,9 @@ FSC\HateoasBundle\Tests\Fixtures\User:
             property: .property
         - rel: adrienbrault
           href: http://adrienbrault.fr
+        - rel: best_friend
+          href:
+              route: _some_route
+              parameters:
+                  id: bestFriend.id
+          required: false


### PR DESCRIPTION
This simply omits the link completely an Symfony\Component\Form\Exception\UnexpectedTypeException is thrown.

In other words, if I have the following config:

``` yml
FSC\HateoasBundle\Tests\Fixtures\User:
    relations:
        - rel: best_friend
          href:
              route: _some_route
              parameters:
                  id: bestFriend.id
          required: false
```

if bestFriend.id does not exist in the User object (meaning null in most cases), then we'd omit the best_friend link completely.

I feel this is less of a hack then doing this manually or creating subscribers for every single object that may need this... Maybe even eventually hooking into the objects validation and seeing what fields are required and taking that value from there by default (since that's what most people would want anyway)

This pertains to #21
