### PR TITLE
Disallow resources from having an array of empty links

### DIFF
--- a/Serializer/EventSubscriber/LinkEventSubscriber.php
+++ b/Serializer/EventSubscriber/LinkEventSubscriber.php
@@ -44,7 +44,7 @@ class LinkEventSubscriber implements EventSubscriberInterface
 
     public function onPostSerializeXML(Event $event)
     {
-        if (null === ($links = $this->linkFactory->createLinks($event->getObject(), $event->getType()))) {
+        if (!$links = $this->linkFactory->createLinks($event->getObject(), $event->getType())) {
             return;
         }
 
@@ -53,8 +53,8 @@ class LinkEventSubscriber implements EventSubscriberInterface
 
     public function onPostSerialize(Event $event)
     {
-        if (null === ($links = $this->getOnPostSerializeData($event))) {
-            return;
+        if (!$links = $this->getOnPostSerializeData($event)) {
+            return null;
         }
 
         $event->getVisitor()->addData($this->linksJsonKey, $links);
@@ -62,8 +62,8 @@ class LinkEventSubscriber implements EventSubscriberInterface
 
     public function getOnPostSerializeData(Event $event)
     {
-        if (null === ($links = $this->linkFactory->createLinks($event->getObject()))) {
-            return;
+        if (!$links = $this->linkFactory->createLinks($event->getObject())) {
+            return null;
         }
 
         $visitor = $event->getVisitor();


### PR DESCRIPTION
Currently, the subscriber only returns null if the links are null, but there's a possibility of the links being empty, thus resulting in an empty array of links.

This removes it.

This is also a fix for #20
