### PR TITLE
Rewrote paged collections with HAL

### DIFF
--- a/Model/PagedCollection.php
+++ b/Model/PagedCollection.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace FSC\HateoasBundle\Model;
+
+use Pagerfanta\PagerfantaInterface;
+
+class PagedCollection implements PagedCollectionInterface
+{
+	/**
+     * The pager that proxies the collection
+     * @var PagerfantaInterface
+     */
+    private $pager;
+
+    /**
+     * The rel for the paged collection
+     * @var string
+     */
+	private $rel;
+
+    /**
+     * @param PagerfantaInterface $pager
+     * @param string              $rel
+     */
+    public function __construct(PagerfantaInterface $pager = null, $rel = "")
+    {
+        $this->pager = $pager;
+        $this->rel = $rel;
+    }
+
+    /**
+     * @param  PagerfantaInterface $pager
+     * @param  string              $rel
+     * @return PagedCollection
+     */
+    public static function create(PagerfantaInterface $pager, $rel)
+    {
+        return new static($pager, $rel);
+    }
+
+	/**
+	 * @param PagerfantaInterface $pager
+	 */
+	public function setPager(PagerfantaInterface $pager)
+	{
+		$this->pager = $pager;
+	}
+
+	/**
+	 * @return PagerfantaInterface
+	 */
+	public function getPager()
+	{
+		return $this->pager;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getRel()
+	{
+	    return $this->rel;
+	}
+
+	/**
+	 * @param string $rel
+	 */
+	public function setRel($rel)
+	{
+	    $this->rel = $rel;
+	}
+}

--- a/Model/PagedCollectionInterface.php
+++ b/Model/PagedCollectionInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace FSC\HateoasBundle\Model;
+
+use Pagerfanta\PagerfantaInterface;
+
+interface PagedCollectionInterface
+{
+    /**
+     * @param PagerfantaInterface $pager
+     */
+    public function setPager(PagerfantaInterface $pager);
+
+    /**
+     * @return PagerfantaInterface
+     */
+    public function getPager();
+
+    /**
+     * @return string
+     */
+    public function getRel();
+
+    /**
+     * @param string $rel
+     */
+    public function setRel($rel);
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -7,6 +7,7 @@ parameters:
     fsc_hateoas.serializer.xml_form_view.class: FSC\HateoasBundle\Serializer\XmlFormViewSerializer
     fsc_hateoas.serializer.event_subscriber.link.class: FSC\HateoasBundle\Serializer\EventSubscriber\LinkEventSubscriber
     fsc_hateoas.serializer.event_subscriber.embedder.class: FSC\HateoasBundle\Serializer\EventSubscriber\EmbedderEventSubscriber
+    fsc_hateoas.serializer.event_subscriber.paged_collection.class: FSC\HateoasBundle\Serializer\EventSubscriber\PagedCollectionSubscriber
     fsc_hateoas.serializer.handler.pagerfanta.class: FSC\HateoasBundle\Serializer\Handler\PagerfantaHandler
     fsc_hateoas.serializer.handler.halpagerfanta.class: FSC\HateoasBundle\Serializer\Handler\HalPagerfantaHandler
     fsc_hateoas.serializer.handler.form_view.class: FSC\HateoasBundle\Serializer\Handler\FormViewHandler
@@ -70,6 +71,11 @@ services:
             - @fsc_hateoas.factory.parameters
             - null
             - %fsc_hateoas.json.relations_key%
+        tags:
+            - { name: jms_serializer.event_subscriber }
+
+    fsc_hateoas.serializer.event_subscriber.paged_collection:
+        class: %fsc_hateoas.serializer.event_subscriber.paged_collection.class%
         tags:
             - { name: jms_serializer.event_subscriber }
 

--- a/Serializer/EventSubscriber/PagedCollectionSubscriber.php
+++ b/Serializer/EventSubscriber/PagedCollectionSubscriber.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace FSC\HateoasBundle\Serializer\EventSubscriber;
+
+use JMS\Serializer\EventDispatcher\PreSerializeEvent;
+use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
+
+use FSC\HateoasBundle\Model\PagedCollectionInterface;
+
+class PagedCollectionSubscriber implements EventSubscriberInterface
+{
+    public function onPreSerialize(PreSerializeEvent $event)
+    {
+        $object = $event->getObject();
+
+        if ($object instanceof PagedCollectionInterface) {
+            $event->setType('FSC\HateoasBundle\Model\PagedCollectionInterface');
+
+            return;
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            array('event' => 'serializer.pre_serialize', 'method' => 'onPreSerialize'),
+        );
+    }
+}


### PR DESCRIPTION
I rewrote the way that paged collections with HAL work to be more flexible and elegant. Now, there is an interface `Model/PagedCollectionInterface.php` that needs to be implemented. There is also a concrete class `Model/PagedCollection.php` that can be inherited from that already has the getters and setters implemented. This interface or class can be used to create custom paginated results. That way, we can use annotations to create additional links for the resources, as well as additional properties (or embedded objects). 

This still needs: 
- [ ] Documentation
- [ ] Updated Unit tests
- [ ] The old HalPager needs to be removed, and I want to rename the Handler to PagedCollectionHandler at that point
- [ ] There are also unit tests failing because of deprecated functions in Symfony. I'll open a separate PR to fix those. This needs to be rebased afterwards.  
