### PR TITLE
Added clear method to RelationsBuilder

### DIFF
--- a/Metadata/Builder/RelationsBuilder.php
+++ b/Metadata/Builder/RelationsBuilder.php
@@ -86,4 +86,9 @@ class RelationsBuilder implements RelationsBuilderInterface
     {
         return $this->relationsMetadata;
     }
+
+    public function clear()
+    {
+        $this->relationsMetadata = array();
+    }
 }

--- a/Tests/Metadata/Builder/RelationsBuilderTest.php
+++ b/Tests/Metadata/Builder/RelationsBuilderTest.php
@@ -170,4 +170,22 @@ class RelationBuilderTest extends \PHPUnit_Framework_TestCase
             'provider' => array('a'),
         ));
     }
+
+    public function testClear()
+    {
+        $RelationsBuilder = new RelationsBuilder();
+
+        $RelationsBuilder->add('self', array('route' => $route = '_some_route'));
+
+        $relationsMetadata = $RelationsBuilder->build();
+
+        $this->assertInternalType('array', $relationsMetadata);
+        $this->assertCount(1, $relationsMetadata);
+
+        $relationsMetadata = $RelationsBuilder->clear();
+        $relationsMetadata = $RelationsBuilder->build();
+
+        $this->assertInternalType('array', $relationsMetadata);
+        $this->assertCount(0, $relationsMetadata);
+    }
 }


### PR DESCRIPTION
I have a use case where I need to create a lot of links with the relation builder. Instead of re-instantiating, it would be easier to just clear it. I was thinking, the clearing could also happen when calling `build()`, but this is the safer, BC way.
