### PR TITLE
Not required relation links

### DIFF
--- a/Annotation/Relation.php
+++ b/Annotation/Relation.php
@@ -21,6 +21,11 @@ final class Relation
     public $href;
 
     /**
+     * @var boolean
+     */
+    public $required = true;
+
+    /**
      * @var \FSC\HateoasBundle\Annotation\Content
      */
     public $embed;

--- a/Exception/RelationRequiredException.php
+++ b/Exception/RelationRequiredException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace FSC\HateoasBundle\Exception;
+
+use FSC\HateoasBundle\Metadata\RelationMetadataInterface;
+
+class RelationRequiredException extends \Exception {
+
+    public function __construct(RelationMetadataInterface $relation, $object){
+        $className = get_class($object);
+        $rel = $relation->getRel();
+
+        return parent::__construct(sprintf('Relation "%s" in "$object" is required', $rel, $className));
+    }
+
+}

--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -37,6 +37,10 @@ class AnnotationDriver implements DriverInterface
             if ($annotation instanceof Annotation\Relation) {
                 $relationMetadata = new RelationMetadata($annotation->rel);
 
+                if(null !== $annotation->required) {
+                    $relationMetadata->setRequired($annotation->required);
+                }
+
                 if ($annotation->href instanceof Annotation\Route) {
                     $relationMetadata->setRoute($annotation->href->value);
                     if (!empty($annotation->href->parameters)) {

--- a/Metadata/RelationMetadata.php
+++ b/Metadata/RelationMetadata.php
@@ -5,6 +5,7 @@ namespace FSC\HateoasBundle\Metadata;
 class RelationMetadata implements RelationMetadataInterface
 {
     private $rel;
+    private $required;
     private $url;
     private $route;
     private $params;
@@ -79,5 +80,18 @@ class RelationMetadata implements RelationMetadataInterface
     public function getUrl()
     {
         return $this->url;
+    }
+
+    public function setRequired($required)
+    {
+        $this->required = (boolean) $required;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequired()
+    {
+        return $this->required;
     }
 }

--- a/Metadata/RelationMetadataInterface.php
+++ b/Metadata/RelationMetadataInterface.php
@@ -10,6 +10,11 @@ interface RelationMetadataInterface
     public function getRel();
 
     /**
+     * @return boolean
+     */
+    public function getRequired();
+
+    /**
      * @return string|null
      */
     public function getUrl();


### PR DESCRIPTION
For example:

```
@FSC\HateoasBundle\Annotation\Relation("http://example.com/rels/images",
  href = @Rest\Route("image_route",
                     parameters = { "imageFile" = ".image.url" }
                     ),
  required = false
 )
```

When sub-entity Image is not exists.
