### PR TITLE
Ability to exclude links based on criteria

### DIFF
--- a/Annotation/Relation.php
+++ b/Annotation/Relation.php
@@ -21,6 +21,11 @@ final class Relation
     public $href;
 
     /**
+     * @var string|array
+     */
+    public $skipIfNull = array();
+
+    /**
      * @var \FSC\HateoasBundle\Annotation\Content
      */
     public $embed;

--- a/Annotation/Relation.php
+++ b/Annotation/Relation.php
@@ -21,11 +21,6 @@ final class Relation
     public $href;
 
     /**
-     * @var string|array
-     */
-    public $skipIfNull = array();
-
-    /**
      * @var \FSC\HateoasBundle\Annotation\Content
      */
     public $embed;
@@ -34,4 +29,9 @@ final class Relation
      * @var array
      */
     public $attributes;
+
+    /**
+     * @var array
+     */
+    public $excludeIf = array();
 }

--- a/Metadata/Builder/RelationsBuilder.php
+++ b/Metadata/Builder/RelationsBuilder.php
@@ -17,7 +17,7 @@ class RelationsBuilder implements RelationsBuilderInterface
         $this->relationsMetadata = array();
     }
 
-    public function add($rel, $href, array $embed = null, array $attributes = null)
+    public function add($rel, $href, array $embed = null, array $attributes = null, array $excludeIf = null)
     {
         $relationMetadata = new RelationMetadata($rel);
 
@@ -84,6 +84,10 @@ class RelationsBuilder implements RelationsBuilderInterface
 
         if (null !== $attributes) {
             $relationMetadata->setAttributes($attributes);
+        }
+
+        if (null !== $excludeIf) {
+            $relationMetadata->setExcludeIf($excludeIf);
         }
 
         $this->relationsMetadata[] = $relationMetadata;

--- a/Metadata/Builder/RelationsBuilderInterface.php
+++ b/Metadata/Builder/RelationsBuilderInterface.php
@@ -4,6 +4,6 @@ namespace FSC\HateoasBundle\Metadata\Builder;
 
 interface RelationsBuilderInterface
 {
-    public function add($rel, $href, array $embed = null, array $attributes = null);
+    public function add($rel, $href, array $embed = null, array $attributes = null, array $excludeIf = null);
     public function build();
 }

--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -37,6 +37,10 @@ class AnnotationDriver implements DriverInterface
             if ($annotation instanceof Annotation\Relation) {
                 $relationMetadata = new RelationMetadata($annotation->rel);
 
+                if (null !== $annotation->skipIfNull) {
+                    $relationMetadata->setSkipIfNull($annotation->skipIfNull);
+                }
+
                 if ($annotation->href instanceof Annotation\Route) {
                     $relationMetadata->setRoute($annotation->href->value);
                     if (!empty($annotation->href->parameters)) {

--- a/Metadata/Driver/AnnotationDriver.php
+++ b/Metadata/Driver/AnnotationDriver.php
@@ -37,8 +37,8 @@ class AnnotationDriver implements DriverInterface
             if ($annotation instanceof Annotation\Relation) {
                 $relationMetadata = new RelationMetadata($annotation->rel);
 
-                if (null !== $annotation->skipIfNull) {
-                    $relationMetadata->setSkipIfNull($annotation->skipIfNull);
+                if (null !== $annotation->excludeIf) {
+                    $relationMetadata->setExcludeIf($annotation->excludeIf);
                 }
 
                 if ($annotation->href instanceof Annotation\Route) {

--- a/Metadata/Driver/YamlDriver.php
+++ b/Metadata/Driver/YamlDriver.php
@@ -50,6 +50,10 @@ class YamlDriver extends AbstractFileDriver
                     $relationMetadata->setAttributes($relation['attributes']);
                 }
 
+                if (!empty($relation['exclude_if'])) {
+                    $relationMetadata->setExcludeIf($relation['exclude_if']);
+                }
+
                 if (!empty($relation['content'])) {
                     $relationContent = $relation['content'];
 

--- a/Metadata/RelationMetadata.php
+++ b/Metadata/RelationMetadata.php
@@ -8,6 +8,7 @@ class RelationMetadata implements RelationMetadataInterface
     private $url;
     private $route;
     private $params;
+    private $skipIfNull = array();
     private $content;
     private $options;
     private $attributes;
@@ -113,5 +114,18 @@ class RelationMetadata implements RelationMetadataInterface
     public function setAttributes($attributes)
     {
         $this->attributes = $attributes;
+    }
+
+    public function setSkipIfNull($skipIfNull)
+    {
+        $this->skipIfNull = (array) $skipIfNull;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSkipIfNull()
+    {
+        return $this->skipIfNull;
     }
 }

--- a/Metadata/RelationMetadata.php
+++ b/Metadata/RelationMetadata.php
@@ -8,15 +8,16 @@ class RelationMetadata implements RelationMetadataInterface
     private $url;
     private $route;
     private $params;
-    private $skipIfNull = array();
     private $content;
     private $options;
     private $attributes;
+    private $excludeIf;
 
     public function __construct($rel)
     {
         $this->rel = $rel;
         $this->params = array();
+        $this->excludeIf = array();
     }
 
     public function setParams($params)
@@ -116,16 +117,19 @@ class RelationMetadata implements RelationMetadataInterface
         $this->attributes = $attributes;
     }
 
-    public function setSkipIfNull($skipIfNull)
+    /**
+     * @param array $excludeIf
+     */
+    public function setExcludeIf(array $excludeIf)
     {
-        $this->skipIfNull = (array) $skipIfNull;
+        $this->excludeIf = (array) $excludeIf;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getSkipIfNull()
+    public function getExcludeIf()
     {
-        return $this->skipIfNull;
+        return $this->excludeIf;
     }
 }

--- a/Metadata/RelationMetadataInterface.php
+++ b/Metadata/RelationMetadataInterface.php
@@ -25,11 +25,6 @@ interface RelationMetadataInterface
     public function getParams();
 
     /**
-     * @return array
-     */
-    public function getSkipIfNull();
-
-    /**
      * @return null|RelationContentMetadataInterface
      */
     public function getContent();
@@ -43,4 +38,10 @@ interface RelationMetadataInterface
      * @return array|null
      */
     public function getAttributes();
+
+    /**
+     * @return array
+     */
+    public function getExcludeIf();
+
 }

--- a/Metadata/RelationMetadataInterface.php
+++ b/Metadata/RelationMetadataInterface.php
@@ -25,6 +25,11 @@ interface RelationMetadataInterface
     public function getParams();
 
     /**
+     * @return array
+     */
+    public function getSkipIfNull();
+
+    /**
      * @return null|RelationContentMetadataInterface
      */
     public function getContent();

--- a/README.md
+++ b/README.md
@@ -666,3 +666,32 @@ class User
 
 }
 ```
+
+## Conditionally excluding links
+
+You can add conditions on relations that will determine whether the link should be excluded or not. For example:
+
+```php
+/**
+ * @Rest\Relation(
+ *      "parent",
+ *      href = @Rest\Route("api_post_get", parameters = { "id" = ".parent.id"}),
+ *      excludeIf = { ".parent" = null }
+ * )
+ */
+class Post
+{
+}
+```
+
+This will not include the `parent` link if the value of `parent` is `null`. This can also be done through the YAML configuration:
+
+```yml
+relations:
+    - rel: parent
+        href:
+            route: api_post_get
+            parameters: { id: .parent.id }
+        exclude_if:
+            ".parent": ~
+```

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -31,6 +31,7 @@ services:
             - @fsc_hateoas.metadata.factory
             - @fsc_hateoas.factory.parameters
             - @fsc_hateoas.routing.relation_url_generator
+            - @fsc_hateoas.property_accessor
 
     fsc_hateoas.factory.parameters:
         class: %fsc_hateoas.factory.parameters.class%

--- a/Tests/Factory/LinkFactoryTest.php
+++ b/Tests/Factory/LinkFactoryTest.php
@@ -111,4 +111,40 @@ class LinkFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($href, $link->getHref());
         $this->assertEquals($attributes, $link->getAttributes());
     }
+
+    public function testLinkNotCreatedWhenShouldBeExcluded()
+    {
+        $urlGenerator = $this->getMock('Symfony\Component\Routing\Generator\UrlGeneratorInterface');
+        $metadataFactory = $this->getMock('FSC\HateoasBundle\Metadata\MetadataFactoryInterface');
+        $parametersFactory = new \FSC\HateoasBundle\Factory\ParametersFactory(new PropertyAccessor());
+
+        $FSCUrlGenerator = new \FSC\HateoasBundle\Routing\UrlGenerator($urlGenerator);
+
+        $relationUrlGenerator = new \FSC\HateoasBundle\Routing\RelationUrlGenerator($metadataFactory, $parametersFactory);
+        $relationUrlGenerator->setUrlGenerator('default', $FSCUrlGenerator);
+
+        $propertyAccessor = new \Symfony\Component\PropertyAccess\PropertyAccessor();
+
+        $linkFactory = new LinkFactory($metadataFactory, $parametersFactory, $relationUrlGenerator, $propertyAccessor);
+
+        $object = (object) array('id' => $id = 3, 'parent' => null);
+
+        $relationMetadata = $this->getMock('FSC\HateoasBundle\Metadata\RelationMetadataInterface');
+        $relationMetadata->expects($this->any())->method('getRel')->will($this->returnValue($rel = 'self'));
+        $relationMetadata->expects($this->any())->method('getRoute')->will($this->returnValue($route = 'bar'));
+        $relationMetadata->expects($this->any())->method('getParams')->will($this->returnValue(array('identifier' => '.id')));
+        $relationMetadata->expects($this->any())->method('getExcludeIf')->will($this->returnValue(array('.parent' => null)));
+
+        $classMetadata = $this->getMock('FSC\HateoasBundle\Metadata\ClassMetadataInterface');
+        $classMetadata->expects($this->once())->method('getRelations')->will($this->returnValue(array($relationMetadata, $relationMetadata)));
+
+        $urlGenerator
+            ->expects($this->never())
+            ->method('generate')
+        ;
+
+        $links = $linkFactory->createLinksFromMetadata($classMetadata, $object);
+
+        $this->assertEquals(0, count($links));
+    }
 }

--- a/Tests/Factory/LinkFactoryTest.php
+++ b/Tests/Factory/LinkFactoryTest.php
@@ -26,7 +26,9 @@ class LinkFactoryTest extends \PHPUnit_Framework_TestCase
         $relationUrlGenerator = new \FSC\HateoasBundle\Routing\RelationUrlGenerator($metadataFactory, $parametersFactory);
         $relationUrlGenerator->setUrlGenerator('default', $FSCUrlGenerator);
 
-        $linkFactory = new LinkFactory($metadataFactory, $parametersFactory, $relationUrlGenerator);
+        $propertyAccessor = new \Symfony\Component\PropertyAccess\PropertyAccessor();
+
+        $linkFactory = new LinkFactory($metadataFactory, $parametersFactory, $relationUrlGenerator, $propertyAccessor);
 
         $object = (object) array('id' => $id = 3);
 
@@ -67,7 +69,9 @@ class LinkFactoryTest extends \PHPUnit_Framework_TestCase
         $relationUrlGenerator = new \FSC\HateoasBundle\Routing\RelationUrlGenerator($metadataFactory, $parametersFactory);
         $relationUrlGenerator->setUrlGenerator('default', $FSCUrlGenerator);
 
-        $linkFactory = new LinkFactory($metadataFactory, $parametersFactory, $relationUrlGenerator);
+        $propertyAccessor = new \Symfony\Component\PropertyAccess\PropertyAccessor();
+
+        $linkFactory = new LinkFactory($metadataFactory, $parametersFactory, $relationUrlGenerator, $propertyAccessor);
 
         $object = (object) array('id' => $id = 3);
 

--- a/Tests/Fixtures/User.php
+++ b/Tests/Fixtures/User.php
@@ -34,6 +34,7 @@ use FSC\HateoasBundle\Annotation as Rest;
  *     embed = @Rest\Content(property = ".property")
  * )
  * @Rest\Relation("templated", href = @Rest\Route("homepage"), attributes = { "isTemplated" = true })
+ * @Rest\Relation("excluded", href = @Rest\Route("homepage"), excludeIf = { ".parent" = null } )
  */
 class User
 {

--- a/Tests/Functional/ControllerTest.php
+++ b/Tests/Functional/ControllerTest.php
@@ -451,4 +451,45 @@ XML
 XML
         , $response->getContent());
     }
+
+    public function testExcludingLinksConditionTrue()
+    {
+        $client = $this->createClient();
+        $client->request('GET', '/api/posts/2/exclude?_format=xml');
+
+        $response = $client->getResponse(); /**  */
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $this->assertEquals(<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<post id="2">
+  <title><![CDATA[How to create awesome symfony2 application]]></title>
+  <link rel="self" href="http://localhost/api/posts/2"/>
+</post>
+
+XML
+        , $response->getContent());
+    }
+
+    public function testExcludingLinksConditionFalse()
+    {
+        $client = $this->createClient();
+        $client->request('GET', '/api/posts/1/exclude?_format=xml');
+
+        $response = $client->getResponse(); /**  */
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $this->assertEquals(<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<post id="1">
+  <title><![CDATA[Welcome on the blog!]]></title>
+  <link rel="self" href="http://localhost/api/posts/1"/>
+  <link rel="parent" href="http://localhost/api/posts/2"/>
+</post>
+
+XML
+        , $response->getContent());
+    }
 }

--- a/Tests/Functional/TestBundle/Controller/PostController.php
+++ b/Tests/Functional/TestBundle/Controller/PostController.php
@@ -69,4 +69,11 @@ class PostController extends Controller
 
         return new Response($this->get('serializer')->serialize($post, $request->get('_format')));
     }
+
+    public function getPostExcludeAction(Request $request, $id)
+    {
+        $post = $this->get('test.provider.post')->getPostExcluded($id);
+
+        return new Response($this->get('serializer')->serialize($post, $request->get('_format')));
+    }
 }

--- a/Tests/Functional/TestBundle/Model/ExcludedPost.php
+++ b/Tests/Functional/TestBundle/Model/ExcludedPost.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace FSC\HateoasBundle\Tests\Functional\TestBundle\Model;
+
+class ExcludedPost extends Post
+{
+    protected $parent;
+
+    public static function create($id, $title, $parent = null)
+    {
+        $post = parent::create($id, $title);
+        $post->setParent($parent);
+
+        return $post;
+    }
+
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    public function setParent($parent)
+    {
+        $this->parent = $parent;
+    }
+}

--- a/Tests/Functional/TestBundle/Provider/PostProvider.php
+++ b/Tests/Functional/TestBundle/Provider/PostProvider.php
@@ -8,6 +8,7 @@ use Pagerfanta\Adapter\ArrayAdapter;
 use FSC\HateoasBundle\Tests\Functional\TestBundle\Model\Post;
 use FSC\HateoasBundle\Tests\Functional\TestBundle\Model\AlternateRouterPost;
 use FSC\HateoasBundle\Tests\Functional\TestBundle\Model\TemplatedPost;
+use FSC\HateoasBundle\Tests\Functional\TestBundle\Model\ExcludedPost;
 
 class PostProvider
 {
@@ -81,6 +82,18 @@ class PostProvider
                 return TemplatedPost::create($id, 'How to create awesome symfony2 application');
             default:
                 return TemplatedPost::create($id, '');
+        }
+    }
+
+    public function getPostExcluded($id)
+    {
+        switch ($id) {
+            case 1:
+                return ExcludedPost::create($id, 'Welcome on the blog!', (object) array('id' => 2));
+            case 2:
+                return ExcludedPost::create($id, 'How to create awesome symfony2 application');
+            default:
+                return ExcludedPost::create($id, '');
         }
     }
 }

--- a/Tests/Functional/TestBundle/Resources/config/hateoas/Model.ExcludedPost.yml
+++ b/Tests/Functional/TestBundle/Resources/config/hateoas/Model.ExcludedPost.yml
@@ -1,0 +1,8 @@
+FSC\HateoasBundle\Tests\Functional\TestBundle\Model\ExcludedPost:
+    relations:
+        - rel: parent
+          href:
+              route: api_post_get
+              parameters: { id: .parent.id }
+          exclude_if:
+              ".parent": ~

--- a/Tests/Functional/TestBundle/Resources/config/serializer/Model.ExcludedPost.yml
+++ b/Tests/Functional/TestBundle/Resources/config/serializer/Model.ExcludedPost.yml
@@ -1,0 +1,5 @@
+FSC\HateoasBundle\Tests\Functional\TestBundle\Model\ExcludedPost:
+    xml_root_name: post
+    properties:
+        id:
+            xml_attribute: true

--- a/Tests/Functional/config/routing.yml
+++ b/Tests/Functional/config/routing.yml
@@ -83,3 +83,10 @@ api_post_get_templated:
         _controller: TestBundle:Post:getPostTemplated
     requirements: { _method: GET }
 
+api_post_get_exclude:
+    pattern: /api/posts/{id}/exclude
+    defaults:
+        _controller: TestBundle:Post:getPostExclude
+    requirements: { _method: GET }
+
+

--- a/Tests/Metadata/Builder/RelationsBuilderTest.php
+++ b/Tests/Metadata/Builder/RelationsBuilderTest.php
@@ -219,4 +219,20 @@ class RelationBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($route, $relationsMetadata[0]->getRoute());
         $this->assertEquals($attributes, $relationsMetadata[0]->getAttributes());
     }
+
+    public function testExcludeIf()
+    {
+        $RelationsBuilder = new RelationsBuilder();
+
+        $excludeIf = array('.parent' => null);
+        $RelationsBuilder->add('self', array('route' => $route = '_some_route'), null, null, $excludeIf);
+
+        $relationsMetadata = $RelationsBuilder->build();
+
+        $this->assertInternalType('array', $relationsMetadata);
+
+        $this->assertInstanceOf('FSC\HateoasBundle\Metadata\RelationMetadataInterface', $relationsMetadata[0]);
+        $this->assertEquals($route, $relationsMetadata[0]->getRoute());
+        $this->assertEquals($excludeIf, $relationsMetadata[0]->getExcludeIf());
+    }
 }

--- a/Tests/Metadata/Driver/CommonDriverTest.php
+++ b/Tests/Metadata/Driver/CommonDriverTest.php
@@ -156,5 +156,18 @@ class CommonDriverTest extends \PHPUnit_Framework_TestCase
             'isTemplated' => true
         );
         $this->assertEquals($expectedAttributes, $relationMetadata->getAttributes());
+
+        $n++;
+
+        $relationMetadata = $relationsMetadata[$n];
+        $this->assertEquals('excluded', $relationMetadata->getRel());
+        $this->assertEquals('homepage', $relationMetadata->getRoute());
+        $this->assertEquals(array(), $relationMetadata->getParams());
+        $this->assertNull($relationMetadata->getContent());
+
+        $expectedExcludedValues = array(
+            '.parent' => null
+        );
+        $this->assertEquals($expectedExcludedValues, $relationMetadata->getExcludeIf());
     }
 }

--- a/Tests/Metadata/Driver/yml/User.yml
+++ b/Tests/Metadata/Driver/yml/User.yml
@@ -50,3 +50,8 @@ FSC\HateoasBundle\Tests\Fixtures\User:
               route: homepage
           attributes:
               isTemplated: true
+        - rel: excluded
+          href:
+              route: homepage
+          exclude_if:
+              ".parent": ~


### PR DESCRIPTION
This is based on discussions in https://github.com/TheFootballSocialClub/FSCHateoasBundle/issues/34 and expands on the PR https://github.com/TheFootballSocialClub/FSCHateoasBundle/pull/36 by @marapper.

I have squashed his 2 commits into one. I have changed the annotation to `excludeIf`, the yml configuration value is `exclude_if`. It now is property path and a value. Example: 

``` php
/**
 * @Rest\Relation(
 *      "parent", 
 *      href = @Rest\Route("api_post_get", parameters = { "id" = ".parent.id"}), 
 *      excludeIf = { ".parent" = null } 
 * )
 */
```

or

``` yml
relations:
    - rel: parent
      href:
          route: api_post_get
          parameters: { id: .parent.id }
      exclude_if:
          ".parent": ~
```
