### PR TITLE
excludeIf should work with @Content too

### DIFF
--- a/Factory/ContentFactory.php
+++ b/Factory/ContentFactory.php
@@ -37,12 +37,19 @@ class ContentFactory implements ContentFactoryInterface
     {
         $relationsContent = new \SplObjectStorage();
 
+        /**
+         * @var RelationMetadataInterface $relationMetadata
+         */
         foreach ($classMetadata->getRelations() as $relationMetadata) {
             if (null === $relationMetadata->getContent()) {
                 continue;
             }
 
-            $relationsContent->attach($relationMetadata, $this->getContent($relationMetadata, $object));
+            if (!$this->parametersFactory->createExclude($object, $relationMetadata->getExcludeIf())
+                && $content = $this->getContent($relationMetadata, $object)
+            ) {
+                $relationsContent->attach($relationMetadata, $content);
+            }
         }
 
         return $relationsContent->count() === 0 ? null : $relationsContent;

--- a/Factory/ParametersFactory.php
+++ b/Factory/ParametersFactory.php
@@ -26,7 +26,8 @@ class ParametersFactory implements ParametersFactoryInterface
         $propertyAccessor = $this->propertyAccessor;
         array_walk($parameters, function (&$value, $key) use ($data, $self, $propertyAccessor) {
             if (is_string($value) && in_array(substr($value, 0, 1), array('.', '['))) {
-                $propertyPath = new PropertyPath(preg_replace('/^\./', '', $value));
+                $value = ltrim($value, '.');
+                $propertyPath = new PropertyPath($value);
                 $value = $propertyAccessor->getValue($data, $propertyPath);
             } elseif ('@' === $value) {
                 $value = $data;
@@ -37,4 +38,28 @@ class ParametersFactory implements ParametersFactoryInterface
 
         return $parameters;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createExclude($object, $excludeIf)
+    {
+        if ( !$excludeIf ) {
+            return false;
+        }
+
+        foreach ($excludeIf as $field => $valueToExclude) {
+            $field = ltrim($field, '.');
+            $propertyPath = new PropertyPath($field);
+
+            $value = $this->propertyAccessor->getValue($object, $propertyPath);
+
+            if ($valueToExclude === $value) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
 }

--- a/Factory/ParametersFactoryInterface.php
+++ b/Factory/ParametersFactoryInterface.php
@@ -4,5 +4,19 @@ namespace FSC\HateoasBundle\Factory;
 
 interface ParametersFactoryInterface
 {
+    /**
+     * @param object $data
+     * @param array  $parameters
+     *
+     * @return mixed
+     */
     public function createParameters($data, $parameters);
+
+    /**
+     * @param object $object
+     * @param array  $excludeIf
+     *
+     * @return boolean
+     */
+    public function createExclude($object, $excludeIf);
 }

--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ class User
 }
 ```
 
-## Conditionally excluding links
+## Conditionally excluding links and embedded relations
 
 You can add conditions on relations that will determine whether the link should be excluded or not. For example:
 
@@ -694,4 +694,19 @@ relations:
             parameters: { id: .parent.id }
         exclude_if:
             ".parent": ~
+```
+
+It is also worked with embedded relations:
+
+```php
+/**
+ * @Rest\Relation(
+ *      "parent",
+ *      embed = @Rest\Content( property = ".childs" ),
+ *      excludeIf = { ".showChilds" = null }
+ * )
+ */
+class Post
+{
+}
 ```

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -31,7 +31,6 @@ services:
             - @fsc_hateoas.metadata.factory
             - @fsc_hateoas.factory.parameters
             - @fsc_hateoas.routing.relation_url_generator
-            - @fsc_hateoas.property_accessor
 
     fsc_hateoas.factory.parameters:
         class: %fsc_hateoas.factory.parameters.class%


### PR DESCRIPTION
ExcludeIf affects only on links. In some cases we need omit embedded relations too.
For example:

   *@Rest\Relation("http://hautelook.com/rels/invitations/reminders",
-     embed = @Rest\Content(property = ".childs"),
-     excludeIf = {".showChilds" = null}
- )
