### PR TITLE
Update to use Symfony 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/framework-bundle": ">=2.1,<2.3-dev",
+        "symfony/framework-bundle": ">=2.1",
         "jms/metadata": "~1.1",
         "jms/serializer": "0.12.*",
         "jms/serializer-bundle": "*",
-        "symfony/property-access": "2.2.*"
+        "symfony/property-access": ">=2.2"
     },
     "require-dev": {
         "symfony/class-loader": "*",
@@ -33,8 +33,8 @@
         "pagerfanta/pagerfanta": "*"
     },
     "suggest": {
-        "symfony/form": ">=2.1,<2.3-dev",
-        "symfony/validator": ">=2.1,<2.3-dev",
+        "symfony/form": ">=2.1",
+        "symfony/validator": ">=2.1",
         "pagerfanta/pagerfanta": "*"
     },
     "autoload": {


### PR DESCRIPTION
This bundle currently does not work if you try to upgrade to Symfony 2.3, which has now been released.
