### PR TITLE
Handle Doctrine proxies correctly in PagerfantaHandler

### DIFF
--- a/Serializer/Handler/PagerfantaHandler.php
+++ b/Serializer/Handler/PagerfantaHandler.php
@@ -83,8 +83,19 @@ class PagerfantaHandler implements SubscribingHandlerInterface
 
         foreach ($pager->getCurrentPageResults() as $result) {
             $elementName = 'entry';
-            if (is_object($result) && null !== ($resultMetadata = $this->serializerMetadataFactory->getMetadataForClass(get_class($result)))) {
-                $elementName = $resultMetadata->xmlRootName ?: $elementName;
+            if (is_object($result)) {
+                $className = get_class($result);
+
+                // Handle Doctrine proxies differently
+                if ($result instanceof Proxy || $result instanceof ORMProxy) {
+                    $result->__load();
+
+                    $className = get_parent_class($result);
+                }
+
+                if(null !== ($resultMetadata = $this->serializerMetadataFactory->getMetadataForClass($className))) {
+                    $elementName = $resultMetadata->xmlRootName ?: $elementName;
+                }
             }
 
             $entryNode = $visitor->getDocument()->createElement($elementName);

--- a/Serializer/Handler/PagerfantaHandler.php
+++ b/Serializer/Handler/PagerfantaHandler.php
@@ -10,7 +10,7 @@ use JMS\Serializer\Context;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
 use Metadata\MetadataFactoryInterface;
 use Pagerfanta\Pagerfanta;
-use Doctrine\Common\Persistence\Proxy;
+use Doctrine\Common\Util\ClassUtils;
 
 use FSC\HateoasBundle\Serializer\EventSubscriber\EmbedderEventSubscriber;
 use FSC\HateoasBundle\Serializer\EventSubscriber\LinkEventSubscriber;
@@ -85,12 +85,7 @@ class PagerfantaHandler implements SubscribingHandlerInterface
         foreach ($pager->getCurrentPageResults() as $result) {
             $elementName = 'entry';
             if (is_object($result)) {
-                $className = get_class($result);
-
-                // Handle Doctrine proxies differently
-                if ($result instanceof Proxy) {
-                    $className = get_parent_class($result);
-                }
+                $className = ClassUtils::getClass($result);
 
                 if(null !== ($resultMetadata = $this->serializerMetadataFactory->getMetadataForClass($className))) {
                     $elementName = $resultMetadata->xmlRootName ?: $elementName;

--- a/Serializer/Handler/PagerfantaHandler.php
+++ b/Serializer/Handler/PagerfantaHandler.php
@@ -11,7 +11,6 @@ use JMS\Serializer\EventDispatcher\ObjectEvent;
 use Metadata\MetadataFactoryInterface;
 use Pagerfanta\Pagerfanta;
 use Doctrine\Common\Persistence\Proxy;
-use Doctrine\ORM\Proxy\Proxy as ORMProxy;
 
 use FSC\HateoasBundle\Serializer\EventSubscriber\EmbedderEventSubscriber;
 use FSC\HateoasBundle\Serializer\EventSubscriber\LinkEventSubscriber;
@@ -89,9 +88,7 @@ class PagerfantaHandler implements SubscribingHandlerInterface
                 $className = get_class($result);
 
                 // Handle Doctrine proxies differently
-                if ($result instanceof Proxy || $result instanceof ORMProxy) {
-                    $result->__load();
-
+                if ($result instanceof Proxy) {
                     $className = get_parent_class($result);
                 }
 

--- a/Serializer/Handler/PagerfantaHandler.php
+++ b/Serializer/Handler/PagerfantaHandler.php
@@ -10,6 +10,8 @@ use JMS\Serializer\Context;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
 use Metadata\MetadataFactoryInterface;
 use Pagerfanta\Pagerfanta;
+use Doctrine\Common\Persistence\Proxy;
+use Doctrine\ORM\Proxy\Proxy as ORMProxy;
 
 use FSC\HateoasBundle\Serializer\EventSubscriber\EmbedderEventSubscriber;
 use FSC\HateoasBundle\Serializer\EventSubscriber\LinkEventSubscriber;

--- a/Tests/Functional/SerializationTest.php
+++ b/Tests/Functional/SerializationTest.php
@@ -2,8 +2,12 @@
 
 namespace FSC\HateoasBundle\Tests\Functional;
 
+use FSC\HateoasBundle\Tests\Functional\TestBundle\Model\UserProxy;
 use FSC\HateoasBundle\Tests\Functional\TestCase;
 use FSC\HateoasBundle\Tests\Functional\TestBundle\Model\User;
+use JMS\Serializer\Tests\Fixtures\SimpleObjectProxy;
+use Pagerfanta\Adapter\ArrayAdapter;
+use Pagerfanta\Pagerfanta;
 
 /**
  * @group functional
@@ -123,6 +127,73 @@ class SerializationTest extends TestCase
     }
 }',
             $user
+        );
+    }
+
+    public function testSerializingDoctrineProxiesToXML()
+    {
+        $user1 = new UserProxy();
+        $user2 = User::create(24, 'Adrien', 'Brault');
+
+        $results = array(
+            $user1,
+            $user2
+        );
+
+        $pager = new Pagerfanta(new ArrayAdapter($results));
+
+        $this->assertSerializedXmlEquals(
+'<collection page="1" limit="10" total="2">
+  <user id="1">
+    <first_name><![CDATA[Ruud]]></first_name>
+    <last_name><![CDATA[Kamphuis]]></last_name>
+    <link rel="self" href="http://localhost/api/users/1"/>
+    <link rel="alternate" href="http://localhost/profile/1"/>
+    <link rel="users" href="http://localhost/api/users"/>
+    <link rel="last-post" href="http://localhost/api/users/1/last-post"/>
+    <link rel="posts" href="http://localhost/api/users/1/posts"/>
+    <link rel="alternate" href="http://localhost/api/users/1/alternate"/>
+    <post rel="last-post" id="2">
+      <title><![CDATA[How to create awesome symfony2 application]]></title>
+      <link rel="self" href="http://localhost/api/posts/2"/>
+    </post>
+    <collection rel="posts" page="1" limit="1" total="2">
+      <link rel="self" href="http://localhost/api/users/1/posts?limit=1&amp;page=1"/>
+      <link rel="first" href="http://localhost/api/users/1/posts?limit=1&amp;page=1"/>
+      <link rel="last" href="http://localhost/api/users/1/posts?limit=1&amp;page=2"/>
+      <link rel="next" href="http://localhost/api/users/1/posts?limit=1&amp;page=2"/>
+      <post id="2">
+        <title><![CDATA[How to create awesome symfony2 application]]></title>
+        <link rel="self" href="http://localhost/api/posts/2"/>
+      </post>
+    </collection>
+  </user>
+  <user id="24">
+    <first_name><![CDATA[Adrien]]></first_name>
+    <last_name><![CDATA[Brault]]></last_name>
+    <link rel="self" href="http://localhost/api/users/24"/>
+    <link rel="alternate" href="http://localhost/profile/24"/>
+    <link rel="users" href="http://localhost/api/users"/>
+    <link rel="last-post" href="http://localhost/api/users/24/last-post"/>
+    <link rel="posts" href="http://localhost/api/users/24/posts"/>
+    <link rel="alternate" href="http://localhost/api/users/24/alternate"/>
+    <post rel="last-post" id="2">
+      <title><![CDATA[How to create awesome symfony2 application]]></title>
+      <link rel="self" href="http://localhost/api/posts/2"/>
+    </post>
+    <collection rel="posts" page="1" limit="1" total="2">
+      <link rel="self" href="http://localhost/api/users/24/posts?limit=1&amp;page=1"/>
+      <link rel="first" href="http://localhost/api/users/24/posts?limit=1&amp;page=1"/>
+      <link rel="last" href="http://localhost/api/users/24/posts?limit=1&amp;page=2"/>
+      <link rel="next" href="http://localhost/api/users/24/posts?limit=1&amp;page=2"/>
+      <post id="2">
+        <title><![CDATA[How to create awesome symfony2 application]]></title>
+        <link rel="self" href="http://localhost/api/posts/2"/>
+      </post>
+    </collection>
+  </user>
+</collection>',
+            $pager
         );
     }
 }

--- a/Tests/Functional/SerializationTest.php
+++ b/Tests/Functional/SerializationTest.php
@@ -2,7 +2,6 @@
 
 namespace FSC\HateoasBundle\Tests\Functional;
 
-use FSC\HateoasBundle\Tests\Functional\TestBundle\Model\UserProxy;
 use FSC\HateoasBundle\Tests\Functional\TestCase;
 use FSC\HateoasBundle\Tests\Functional\TestBundle\Model\User;
 use JMS\Serializer\Tests\Fixtures\SimpleObjectProxy;
@@ -132,7 +131,9 @@ class SerializationTest extends TestCase
 
     public function testSerializingDoctrineProxiesToXML()
     {
-        $user1 = new UserProxy();
+        require __DIR__ . "/TestBundle/Model/UserProxy.php";
+
+        $user1 = new \Proxies\__CG__\FSC\HateoasBundle\Tests\Functional\TestBundle\Model\User;
         $user2 = User::create(24, 'Adrien', 'Brault');
 
         $results = array(

--- a/Tests/Functional/SerializationTest.php
+++ b/Tests/Functional/SerializationTest.php
@@ -154,6 +154,7 @@ class SerializationTest extends TestCase
     <link rel="last-post" href="http://localhost/api/users/1/last-post"/>
     <link rel="posts" href="http://localhost/api/users/1/posts"/>
     <link rel="alternate" href="http://localhost/api/users/1/alternate"/>
+    <link rel="dynamic_href" href="this/is/a/href/from/a/property_path"/>
     <post rel="last-post" id="2">
       <title><![CDATA[How to create awesome symfony2 application]]></title>
       <link rel="self" href="http://localhost/api/posts/2"/>
@@ -178,6 +179,7 @@ class SerializationTest extends TestCase
     <link rel="last-post" href="http://localhost/api/users/24/last-post"/>
     <link rel="posts" href="http://localhost/api/users/24/posts"/>
     <link rel="alternate" href="http://localhost/api/users/24/alternate"/>
+    <link rel="dynamic_href" href="this/is/a/href/from/a/property_path"/>
     <post rel="last-post" id="2">
       <title><![CDATA[How to create awesome symfony2 application]]></title>
       <link rel="self" href="http://localhost/api/posts/2"/>

--- a/Tests/Functional/TestBundle/Model/User.php
+++ b/Tests/Functional/TestBundle/Model/User.php
@@ -4,9 +4,9 @@ namespace FSC\HateoasBundle\Tests\Functional\TestBundle\Model;
 
 class User
 {
-    private $id;
-    private $firstName;
-    private $lastName;
+    protected $id;
+    protected $firstName;
+    protected $lastName;
 
     public function setId($id)
     {

--- a/Tests/Functional/TestBundle/Model/UserProxy.php
+++ b/Tests/Functional/TestBundle/Model/UserProxy.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace FSC\HateoasBundle\Tests\Functional\TestBundle\Model;
+namespace Proxies\__CG__\FSC\HateoasBundle\Tests\Functional\TestBundle\Model;
 
 use Doctrine\Common\Persistence\Proxy;
 
-class UserProxy extends User implements Proxy
+class User extends \FSC\HateoasBundle\Tests\Functional\TestBundle\Model\User implements Proxy
 {
     public $__isInitialized__ = false;
 

--- a/Tests/Functional/TestBundle/Model/UserProxy.php
+++ b/Tests/Functional/TestBundle/Model/UserProxy.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace FSC\HateoasBundle\Tests\Functional\TestBundle\Model;
+
+use Doctrine\Common\Persistence\Proxy;
+
+class UserProxy extends User implements Proxy
+{
+    public $__isInitialized__ = false;
+
+    public function __load()
+    {
+        if (!$this->__isInitialized__) {
+            $this->id = 1;
+            $this->firstName = "Ruud";
+            $this->lastName = "Kamphuis";
+
+            $this->__isInitialized__ = true;
+        }
+    }
+
+    public function __isInitialized()
+    {
+        return $this->__isInitialized__;
+    }
+}


### PR DESCRIPTION
JMSSerializerBundle has a [DoctrineProxySubscriber](https://github.com/schmittjoh/serializer/blob/master/src/JMS/Serializer/EventDispatcher/Subscriber/DoctrineProxySubscriber.php) which loads Doctrine Proxies before serializing them.

When I serialize a Pagerfanta object with, for example, 2 users. One user is a Proxy and 1 user is loaded completely. I've set `@XmlRoot("user")`. When I serialize the Pagerfanta object to XML one user has a `<entry>` root and one has a `<user>` root.

This PR fixes it.
