### PR TITLE
Avoid linking to page 0

### DIFF
--- a/Metadata/RelationsManager.php
+++ b/Metadata/RelationsManager.php
@@ -106,7 +106,7 @@ class RelationsManager implements RelationsManagerInterface
 
         $relationsBuilder->add('last', array(
             'route' => $route,
-            'parameters' => array_merge($routeParameters, array($pageParameterName => ($pager->getNbPages() != 0)?:1))
+            'parameters' => array_merge($routeParameters, array($pageParameterName => ($pager->getNbPages()>0)?$pager->getNbPages():1))
         ));
 
         if ($pager->hasPreviousPage()) {

--- a/Metadata/RelationsManager.php
+++ b/Metadata/RelationsManager.php
@@ -106,7 +106,7 @@ class RelationsManager implements RelationsManagerInterface
 
         $relationsBuilder->add('last', array(
             'route' => $route,
-            'parameters' => array_merge($routeParameters, array($pageParameterName => $pager->getNbPages()))
+            'parameters' => array_merge($routeParameters, array($pageParameterName => ($pager->getNbPages() != 0)?:1))
         ));
 
         if ($pager->hasPreviousPage()) {


### PR DESCRIPTION
When a pager has no data, the generated url for `last` rel has a query param `page` with a value of `0`.

When you visit this link and try to set the current page, an exception thrown because the `PagerFanta::setCurrentPage` does not allow a value lower than `1`.

So, when the pager is empty, the `last` rel link `page` param should be `1`
