### PR TITLE
exclude form-serializer versions with symlink

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "jms/serializer": ">=0.12.0,<0.15.0-dev",
         "jms/serializer-bundle": "*",
         "symfony/property-access": "~2.2",
-        "adrienbrault/form-serializer": "0.1.*,>=0.1.2"
+        "adrienbrault/form-serializer": "~0.1.2"
     },
     "require-dev": {
         "symfony/class-loader": "*",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "jms/serializer": ">=0.12.0,<0.15.0-dev",
         "jms/serializer-bundle": "*",
         "symfony/property-access": "~2.2",
-        "adrienbrault/form-serializer": "0.1.*"
+        "adrienbrault/form-serializer": "0.1.*,>=0.1.2"
     },
     "require-dev": {
         "symfony/class-loader": "*",


### PR DESCRIPTION
Hi guys,

As form-serializer got some versions with a symlink which break our satis, this will ignore those useless versions.

Thanks,

Jérémy
