### PR TITLE
Added method to disable links on request basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,16 @@ class RootController extends Controller
 </root>
 ```
 
+## Disable links
+
+Under certain circumstances it might be desired to disable the output of relation links. The output can be turned
+off like this:
+
+```php
+$container->get('fsc_hateoas.serializer.metadata_helper')->disableLinks();
+```
+
+
 ## Json Format
 
 The bundle supports customizing the keys of links and embedded relations when serializing to Json. They are

--- a/Serializer/EventSubscriber/LinkEventSubscriber.php
+++ b/Serializer/EventSubscriber/LinkEventSubscriber.php
@@ -52,6 +52,10 @@ class LinkEventSubscriber implements EventSubscriberInterface
 
     public function onPostSerializeXML(Event $event)
     {
+        if ($this->metadataHelper->areLinksDisabled()) {
+            return;
+        }
+
         if (null === ($links = $this->linkFactory->createLinks($event->getObject(), $event->getType()))) {
             return;
         }
@@ -61,6 +65,10 @@ class LinkEventSubscriber implements EventSubscriberInterface
 
     public function onPostSerialize(Event $event)
     {
+        if ($this->metadataHelper->areLinksDisabled()) {
+            return;
+        }
+
         $links = $this->getOnPostSerializeData($event);
 
         if (empty($links)) {

--- a/Serializer/MetadataHelper.php
+++ b/Serializer/MetadataHelper.php
@@ -9,6 +9,8 @@ class MetadataHelper
 {
     protected $serializerMetadataFactory;
 
+    protected $linksDisabled = false;
+
     public function __construct(MetadataFactory $serializerMetadataFactory)
     {
         $this->serializerMetadataFactory = $serializerMetadataFactory;
@@ -42,5 +44,20 @@ class MetadataHelper
         $classMetadata = $this->serializerMetadataFactory->getMetadataForClass(get_class($object));
 
         return $classMetadata->xmlRootName;
+    }
+
+    public function disableLinks()
+    {
+        $this->linksDisabled = true;
+    }
+
+    public function enableLinks()
+    {
+        $this->linksDisabled = false;
+    }
+
+    public function areLinksDisabled()
+    {
+        return $this->linksDisabled;
     }
 }

--- a/Tests/Functional/ControllerTest.php
+++ b/Tests/Functional/ControllerTest.php
@@ -98,6 +98,22 @@ XML
             , $response->getContent());
     }
 
+    public function testRootControllerDisabledLinksXml()
+    {
+        $client = $this->createClient();
+        $client->request('GET', '/api/disabled_links?_format=xml');
+
+        $response = $client->getResponse(); /** @var $response Response */
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<root/>
+
+XML
+            , $response->getContent());
+    }
+
     public function testRootRuntimeMetadataControllerXml()
     {
         $client = $this->createClient();

--- a/Tests/Functional/TestBundle/Controller/RootController.php
+++ b/Tests/Functional/TestBundle/Controller/RootController.php
@@ -27,6 +27,16 @@ class RootController extends Controller
         return new Response($this->get('serializer')->serialize($root, $request->get('_format')));
     }
 
+    public function disabledLinksAction(Request $request)
+    {
+        $root = new Root();
+
+        $this->get('fsc_hateoas.metadata.relations_manager')->addRelation($root, 'adrienbrault', 'http://adrienbrault.fr');
+        $this->get('fsc_hateoas.serializer.metadata_helper')->disableLinks();
+
+        return new Response($this->get('serializer')->serialize($root, $request->get('_format')));
+    }
+
     public function emptyAction(Request $request)
     {
         $data = new EmptyRoot();

--- a/Tests/Functional/config/routing.yml
+++ b/Tests/Functional/config/routing.yml
@@ -8,6 +8,11 @@ api_root_empty:
     defaults:
         _controller: TestBundle:Root:empty
 
+api_root_disabled_links:
+    pattern: /api/disabled_links
+    defaults:
+        _controller: TestBundle:Root:disabledLinks
+
 api_user_get:
     pattern: /api/users/{identifier}
 


### PR DESCRIPTION
Allows to disable link output like this:
`$this->get('fsc_hateoas.serializer.metadata_helper')->disableLinks();`

This is helpful if you want the option to hide Hateoas links under certain circumstances.

If there is a better way to accomplish this, please let me know.
